### PR TITLE
FIX Ensure CMS history tab has a hidden ID field to prevent switching back to Content tab

### DIFF
--- a/src/Controllers/CMSPageHistoryViewerController.php
+++ b/src/Controllers/CMSPageHistoryViewerController.php
@@ -5,6 +5,7 @@ namespace SilverStripe\VersionedAdmin\Controllers;
 use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
+use SilverStripe\Forms\HiddenField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\VersionedAdmin\Forms\HistoryViewerField;
 
@@ -37,6 +38,7 @@ class CMSPageHistoryViewerController extends CMSMain
 
         if ($record) {
             $fieldList = FieldList::create(
+                HiddenField::create('ID', null, $record->ID),
                 HistoryViewerField::create('PageHistory')
                     ->setForm($form)
             );


### PR DESCRIPTION
Fixes #3 

The issue is that there was no ID field present, so LeftAndMain.Preview.js would render the edit panel again:

https://github.com/silverstripe/silverstripe-admin/blob/4166209a16069151260c90285f5a347ea2ce8276/client/src/legacy/LeftAndMain.Preview.js#L526-L530