### PR TITLE
Add Behat feature and (context) to view a list of versions in History Viewer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - export PATH=~/.composer/vendor/bin:$PATH
   - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
-  # Install composer
+# Install composer
   - composer validate
   - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql 2.0.x-dev; fi
   - composer require --no-update silverstripe/recipe-testing:^1 silverstripe/recipe-cms 1.2.x-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
   - export PATH=~/.composer/vendor/bin:$PATH
   - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
-# Install composer
+  # Install composer
   - composer validate
   - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql 2.0.x-dev; fi
   - composer require --no-update silverstripe/recipe-testing:^1 silverstripe/recipe-cms 1.2.x-dev

--- a/tests/Behat/Context/FeatureContext.php
+++ b/tests/Behat/Context/FeatureContext.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\VersionedAdmin\Tests\Behat\Context;
 
+use Behat\Mink\Element\NodeElement;
 use SilverStripe\BehatExtension\Context\SilverStripeContext;
 
 if (!class_exists(SilverStripeContext::class)) {
@@ -21,17 +22,113 @@ class FeatureContext extends SilverStripeContext
     }
 
     /**
+     * @Then I should see a list of versions in descending order
+     */
+    public function iShouldSeeAListOfVersionsInDescendingOrder()
+    {
+        $page = $this->getSession()->getPage();
+        $versions = $page->findAll('css', '.history-viewer .table tbody tr td:nth-of-type(1)');
+
+        $previous = null;
+        foreach ($versions as $version) {
+            /** @var NodeElement $version */
+            if ($previous) {
+                assert($version->getValue() < $previous);
+            }
+            $previous = $version->getValue();
+        }
+    }
+
+    /**
      * @When I click on the first version
      */
     public function iClickOnTheFirstVersion()
     {
-        $page = $this->getSession()->getPage();
-        $firstVersion = $page->find('css', '.history-viewer .table tbody tr');
-        assertNotNull($firstVersion, 'I should see a list of versions');
-
-        $firstVersion->click();
+        assertNotNull($this->getLatestVersion(), 'I should see a list of versions');
+        $this->getLatestVersion()->click();
 
         // Wait for the form builder to load
         $this->getSession()->wait(3000);
+    }
+
+    /**
+     * Example: I should see the "Live" badge
+     * Example: I should not see the "Live" badge
+     *
+     * @Then /^I should (not |)see the "([\w\s]+)" badge$/
+     * @param string $negative
+     * @param string $text
+     */
+    public function iShouldSeeTheBadge($negative, $text)
+    {
+        if ($negative) {
+            $this->assertElementNotOnPage('.history-viewer .badge');
+        } else {
+            $this->assertElementContains('.history-viewer .badge', $text);
+        }
+    }
+
+    /**
+     * Example: I should see "ADMIN User" in the author column in version 1
+     *
+     * @Then I should see :text in the author column in version :versionNumber
+     */
+    public function iShouldSeeInTheAuthorColumn($text, $versionNumber)
+    {
+        $version = $this->getSpecificVersion($versionNumber);
+        $authorColumn = $version->find('css', 'td:nth-of-type(3)');
+
+        $exists = strpos($authorColumn->getText(), $text) !== false;
+        assertTrue($exists, 'Author column contains ' . $text);
+    }
+
+    /**
+     * Example: I should see "Saved" in the record column in version 1
+     *
+     * @Then I should see :text in the record column in version :versionNumber
+     */
+    public function iShouldSeeInTheRecordColumn($text, $versionNumber)
+    {
+        $version = $this->getSpecificVersion($versionNumber);
+        $recordColumn = $version->find('css', 'td:nth-of-type(2)');
+
+        $exists = strpos($recordColumn->getText(), $text) !== false;
+        assertTrue($exists, 'Record column contains ' . $text);
+    }
+
+    /**
+     * @Then I should see :text in the version column in version :versionNumber
+     */
+    public function iShouldSeeInTheVersionColumn($text, $versionNumber)
+    {
+        $version = $this->getSpecificVersion($versionNumber);
+        $versionColumn = $version->find('css', 'td');
+
+        $exists = strpos($versionColumn->getText(), $text) !== false;
+        assertTrue($exists, 'Version column contains ' . $text);
+    }
+
+    /**
+     * Returns the table row that holds information on the most recent version
+     */
+    protected function getLatestVersion()
+    {
+        $page = $this->getSession()->getPage();
+        return $page->find('css', '.history-viewer .table tbody tr');
+    }
+
+    /**
+     * Returns the table row that holds information on the selected version.
+     *
+     * @param int $versionNumber
+     */
+    protected function getSpecificVersion($versionNumber)
+    {
+        $versionColumns = $this->getSession()->getPage()->findAll('css', '.history-viewer tbody tr');
+        foreach ($versionColumns as $version) {
+            if (strpos($version->getText(), $versionNumber) !== false) {
+                return $version;
+            }
+        }
     }
 }

--- a/tests/Behat/features/list-view.feature
+++ b/tests/Behat/features/list-view.feature
@@ -1,0 +1,52 @@
+@javascript
+Feature: View a list of versions
+  As a cms author
+  I want to view a list past revisions of a versioned DataObject (incl. pages)
+
+  Background:
+    # Test date cannot be in the past or the version list numbers won't be descending
+    Given the current date is "2100-01-01"
+    Given a "page" "Home" with "Content"="Background"
+
+    Given I am logged in with "ADMIN" permissions
+    And I go to "/admin/pages"
+    And I click on "Home" in the tree
+
+  Scenario: A list of versions is displayed
+    Given I click on "History" in the header tabs
+    Then I should see a list of versions
+
+  Scenario: List shows the publish state, publish date and the author
+    Given I should see an edit page form
+    When I fill in the "Content" HTML field with "<p>Publish scenario</p>"
+    And I press the "Publish" button
+    Then I should see a "Published 'Home' successfully." notice
+    # This is a workaround @todo remove when https://github.com/silverstripe/silverstripe-cms/issues/2128 is resolved in framework
+    And I go to "/admin/pages/history/show/1"
+    Then I should see a list of versions
+    And I should see "ADMIN User" in the author column in version 1
+    And I should see "Published" in the record column in version 1
+    And I should see "01/01/2100" in the record column in version 1
+    And I should see the "Live" badge
+
+  Scenario: List shows the draft state, draft date and the author
+    Given I should see an edit page form
+    When I fill in the "Content" HTML field with "<p>Save scenario</p>"
+    And I press the "Save" button
+    Then I should see a "Saved 'Home' successfully." notice
+    # This is a workaround @todo remove when https://github.com/silverstripe/silverstripe-cms/issues/2128 is resolved in framework
+    And I go to "/admin/pages/history/show/1"
+    Then I should see a list of versions
+    And I should see "ADMIN User" in the author column in version 1
+    And I should see "Saved" in the record column in version 1
+    And I should see "01/01/2100" in the record column in version 1
+    And I should not see the "Live" badge
+
+  Scenario: Revisions are ordered descending by date
+    Given I should see an edit page form
+    When I fill in the "Content" HTML field with "<p>Order scenario</p>"
+    And I press the "Publish" button
+    Then I should see a "Published 'Home' successfully." notice
+    # This is a workaround @todo remove when https://github.com/silverstripe/silverstripe-cms/issues/2128 is resolved in framework
+    And I go to "/admin/pages/history/show/1"
+    Then I should see a list of versions in descending order

--- a/tests/Behat/features/view-a-version.feature
+++ b/tests/Behat/features/view-a-version.feature
@@ -13,10 +13,14 @@ Feature: View a version
 
   Scenario: I can view a selected version of a record
     When I click on the first version
+    And I wait for 3 seconds until I see the "#Form_versionForm" element
     Then I should see "Welcome to my website"
 
-  Scenario: The form fields shown are readonly
+  Scenario: Shows readonly version of all core form fields
+    Given I click on "History" in the header tabs
+    Then I should see a list of versions
+
     When I click on the first version
+    And I wait for 3 seconds until I see the "#Form_versionForm" element
     Then I should see an "#Form_versionForm_Title[readonly]" element
     And I should see an "#Form_versionForm_URLSegment[readonly]" element
-

--- a/tests/Behat/features/view-a-version.feature
+++ b/tests/Behat/features/view-a-version.feature
@@ -19,3 +19,4 @@ Feature: View a version
     When I click on the first version
     Then I should see an "#Form_versionForm_Title[readonly]" element
     And I should see an "#Form_versionForm_URLSegment[readonly]" element
+


### PR DESCRIPTION
Additions were made to the FeatureContext to allow to assert text being contained within specific columns within specific versions. The intention is that this allows modularity for further tests.

Note that the following workaround `And I go to "/admin/pages/history/show/1"` was used to navigate to the History, rather than clicking the History tab. This is because of the popup notice that hides (and prevents from clicking) the History tab - see: https://github.com/silverstripe/silverstripe-cms/issues/2128 Unfortunately, dismissing the pop up and waiting for it to fade away has been unreliable. 
