### PR TITLE
NEW Allow history viewer to be activated by modules rather than always on

### DIFF
--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -5,7 +5,8 @@ Only:
 ---
 SilverStripe\Core\Injector\Injector:
   SilverStripe\CMS\Controllers\CMSPageHistoryController:
-    class: SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController
+    factory:
+      SilverStripe\VersionedAdmin\Controllers\HistoryControllerFactory
 
 SilverStripe\CMS\Controllers\CMSMain:
   extensions:

--- a/behat.yml
+++ b/behat.yml
@@ -21,7 +21,7 @@ default:
             - %paths.modules.versioned-admin%/tests/behat/files/
         -
           SilverStripe\Framework\Tests\Behaviour\ConfigContext:
-            - %paths.modules.versioned-admin%/tests/behat/files/
+            - %paths.modules.versioned-admin%/tests/Behat/config
   extensions:
     SilverStripe\BehatExtension\MinkExtension:
       default_session: facebook_web_driver

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,10 @@
         "squizlabs/php_codesniffer": "^3",
         "silverstripe/cms": "^4.2@dev"
     },
+    "scripts": {
+        "lint": "phpcs src/ tests/",
+        "lint-clean": "phpcbf src/ tests/"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,5 +6,6 @@
     <rule ref="PSR2" >
         <!-- Current exclusions -->
         <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
     </rule>
 </ruleset>

--- a/src/Controllers/HistoryControllerFactory.php
+++ b/src/Controllers/HistoryControllerFactory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ *
+ */
+
+namespace SilverStripe\VersionedAdmin\Controllers;
+
+use SilverStripe\CMS\Controllers\CMSPageHistoryController;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Factory;
+use SilverStripe\Core\Injector\Injector;
+
+class HistoryControllerFactory implements Factory
+{
+    use Extensible;
+
+    public function create($service, array $params = array())
+    {
+        $request = Injector::inst()->get(HTTPRequest::class);
+        $id = $request->param('ID');
+
+        if ($id) {
+            $page = SiteTree::get()->byID($id);
+            if ($page && $this->isEnabled($page)) {
+                return Injector::inst()->create(CMSPageHistoryViewerController::class);
+            }
+        }
+
+        // Injector is not used to prevent an infinite loop
+        return new CMSPageHistoryController();
+    }
+
+    /**
+     * Only activate for pages that have a history viewer capability applied. Extensions can provide their
+     * own two cents about this criteria.
+     *
+     * @param SiteTree $record
+     * @return bool
+     */
+    public function isEnabled(SiteTree $record)
+    {
+        $enabledResults = array_filter($this->extend('updateIsEnabled', $record));
+        return (!empty($enabledResults) && max($enabledResults) === true);
+    }
+
+}

--- a/src/Controllers/HistoryControllerFactory.php
+++ b/src/Controllers/HistoryControllerFactory.php
@@ -44,5 +44,4 @@ class HistoryControllerFactory implements Factory
         $enabledResults = array_filter($this->extend('updateIsEnabled', $record));
         return (!empty($enabledResults) && max($enabledResults) === true);
     }
-
 }

--- a/src/Controllers/HistoryViewerController.php
+++ b/src/Controllers/HistoryViewerController.php
@@ -12,8 +12,12 @@ use SilverStripe\Forms\FormFactory;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\VersionedAdmin\Forms\DataObjectVersionFormFactory;
 
+/**
+ * The HistoryViewerController provides AJAX endpoints for React to enable functionality, such as retrieving the form
+ * schema.
+ */
 class HistoryViewerController extends LeftAndMain
-{
+
     private static $url_segment = 'historyviewer';
 
     private static $url_rule = '/$Action';

--- a/src/Controllers/HistoryViewerController.php
+++ b/src/Controllers/HistoryViewerController.php
@@ -17,6 +17,7 @@ use SilverStripe\VersionedAdmin\Forms\DataObjectVersionFormFactory;
  * schema.
  */
 class HistoryViewerController extends LeftAndMain
+{
 
     private static $url_segment = 'historyviewer';
 

--- a/src/Forms/DataObjectVersionFormFactory.php
+++ b/src/Forms/DataObjectVersionFormFactory.php
@@ -7,13 +7,11 @@ use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormFactory;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\Tab;
-use SilverStripe\Forms\TabSet;
 use SilverStripe\ORM\DataObject;
 
 class DataObjectVersionFormFactory implements FormFactory

--- a/tests/Behat/Stub/EnableHistoryViewerExtension.php
+++ b/tests/Behat/Stub/EnableHistoryViewerExtension.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Behat\Stub;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class EnableHistoryViewerExtension extends Extension implements TestOnly
+{
+    public function updateIsEnabled()
+    {
+        return true;
+    }
+}

--- a/tests/Behat/config/enable-historyviewer.yml
+++ b/tests/Behat/config/enable-historyviewer.yml
@@ -1,0 +1,6 @@
+---
+Name: testonly-enable-historyviewer
+---
+SilverStripe\VersionedAdmin\Controllers\HistoryControllerFactory:
+  extensions:
+    - SilverStripe\VersionedAdmin\Tests\Behat\Stub\EnableHistoryViewerExtension

--- a/tests/Behat/features/list-view.feature
+++ b/tests/Behat/features/list-view.feature
@@ -6,7 +6,8 @@ Feature: View a list of versions
   Background:
     # Test date cannot be in the past or the version list numbers won't be descending
     Given the current date is "2100-01-01"
-    Given a "page" "Home" with "Content"="Background"
+    And I have a config file "enable-historyviewer.yml"
+    And a "page" "Home" with "Content"="Background"
 
     Given I am logged in with "ADMIN" permissions
     And I go to "/admin/pages"
@@ -14,6 +15,7 @@ Feature: View a list of versions
 
   Scenario: A list of versions is displayed
     Given I click on "History" in the header tabs
+    And I put a breakpoint
     Then I should see a list of versions
 
   Scenario: List shows the publish state, publish date and the author

--- a/tests/Behat/features/list-view.feature
+++ b/tests/Behat/features/list-view.feature
@@ -15,7 +15,6 @@ Feature: View a list of versions
 
   Scenario: A list of versions is displayed
     Given I click on "History" in the header tabs
-    And I put a breakpoint
     Then I should see a list of versions
 
   Scenario: List shows the publish state, publish date and the author

--- a/tests/Behat/features/view-a-version.feature
+++ b/tests/Behat/features/view-a-version.feature
@@ -5,6 +5,8 @@ Feature: View a version
 
   Background:
     Given a "page" "Home" with "Content"="Welcome to my website"
+    And I have a config file "enable-historyviewer.yml"
+
     Given I am logged in with "ADMIN" permissions
     And I go to "/admin/pages"
     And I click on "Home" in the tree

--- a/tests/Controllers/CMSPageHistoryViewerControllerTest.php
+++ b/tests/Controllers/CMSPageHistoryViewerControllerTest.php
@@ -19,6 +19,7 @@ class CMSPageHistoryViewerControllerTest extends SapphireTest
         $id = $this->idFromFixture(SiteTree::class, 'page_one');
 
         $controller = CMSPageHistoryViewerController::create();
+
         $controller->setRequest(
             (new HTTPRequest('GET', '/'))
                 ->setSession(new Session([]))


### PR DESCRIPTION
Resolves  https://github.com/silverstripe/silverstripe-versioned-admin/issues/15

This allows the data record to provide context to whether the history viewer should be activated or not. Example activation point: https://github.com/dnadesign/silverstripe-elemental/pull/231