### PR TITLE
FIX Ensure history controller factory reads current page from Draft stage

### DIFF
--- a/src/Controllers/HistoryControllerFactory.php
+++ b/src/Controllers/HistoryControllerFactory.php
@@ -1,7 +1,4 @@
 <?php
-/**
- *
- */
 
 namespace SilverStripe\VersionedAdmin\Controllers;
 
@@ -11,7 +8,12 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Factory;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Versioned\Versioned;
 
+/**
+ * The history controller factory decides which CMS history controller to use, out of the default from the
+ * silverstripe/cms module or the history viewer controller from this module, depending on the current page type
+ */
 class HistoryControllerFactory implements Factory
 {
     use Extensible;
@@ -22,7 +24,12 @@ class HistoryControllerFactory implements Factory
         $id = $request->param('ID');
 
         if ($id) {
+            // Ensure we read from the draft stage at this position
+            $originalStage = Versioned::get_stage();
+            Versioned::set_stage(Versioned::DRAFT);
             $page = SiteTree::get()->byID($id);
+            Versioned::set_stage($originalStage);
+
             if ($page && $this->isEnabled($page)) {
                 return Injector::inst()->create(CMSPageHistoryViewerController::class);
             }


### PR DESCRIPTION
In #13 this change had originally made a behat test fail, perhaps the test has been updated so workaround that, but this is the fix to ensure that the page can be loaded when the reading mode is Stage.Live