### PR TITLE
FIX Return default history controller when no request is available in injector

### DIFF
--- a/src/Controllers/HistoryControllerFactory.php
+++ b/src/Controllers/HistoryControllerFactory.php
@@ -20,6 +20,10 @@ class HistoryControllerFactory implements Factory
 
     public function create($service, array $params = array())
     {
+        // If no request is available yet, return the default controller
+        if (!Injector::inst()->has(HTTPRequest::class)) {
+            return new CMSPageHistoryController();
+        }
         $request = Injector::inst()->get(HTTPRequest::class);
         $id = $request->param('ID');
 


### PR DESCRIPTION
Particuarly in unit testing, there may not always be a request available at this point. This patch checks first and returns the default history controller if there isn't one available yet.

Example:

```
1) Symbiote\QueuedJobs\Tests\QueuedJobsAdminTest::testConstructorParamsShouldBeATextarea
Missing argument 1 for SilverStripe\Control\HTTPRequest::__construct()
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/framework/src/Control/HTTPRequest.php:157
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/InjectionCreator.php:26
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:585
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:988
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:941
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/versioned-admin/src/Controllers/HistoryControllerFactory.php:23
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:585
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:988
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/Injector/Injector.php:941
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/admin/code/LeftAndMain.php:290
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/admin/code/LeftAndMain.php:673
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/admin/code/ModelAdmin.php:142
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/silverstripe/framework/src/Control/Controller.php:127
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/symbiote/silverstripe-queuedjobs/tests/QueuedJobsAdminTest.php:56
/home/travis/build/silverstripe/cwp-recipe-kitchen-sink/vendor/phpunit/phpunit/phpunit:52
```