### PR TITLE
FIX Lower URL priority so controller is not auto loaded over CMSPageHistoryController

### DIFF
--- a/src/Controllers/CMSPageHistoryViewerController.php
+++ b/src/Controllers/CMSPageHistoryViewerController.php
@@ -24,7 +24,7 @@ class CMSPageHistoryViewerController extends CMSMain
 
     private static $url_rule = '/$Action/$ID/$VersionID/$OtherVersionID';
 
-    private static $url_priority = 42;
+    private static $url_priority = 41;
 
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 

--- a/tests/Behat/features/revert-to-a-version.feature
+++ b/tests/Behat/features/revert-to-a-version.feature
@@ -6,6 +6,8 @@ Feature: Revert to a version
 
   Background:
     Given a "page" "Home" with "Content"="Initial version"
+    And I have a config file "enable-historyviewer.yml"
+
     Given I am logged in with "ADMIN" permissions
     And I go to "/admin/pages"
     And I click on "Home" in the tree


### PR DESCRIPTION
We use the HistoryControllerFactory to determine this instead.

This meant that in practice the factory response was being ignored in favour of this controller anyway. Testing with this fix in place resolves the issue.

Fixes https://github.com/silverstripe/cwp/issues/110