### PR TITLE
FIX Use get_one_by_stage when fetching SiteTree for a specific stage

### DIFF
--- a/src/Controllers/HistoryControllerFactory.php
+++ b/src/Controllers/HistoryControllerFactory.php
@@ -29,10 +29,11 @@ class HistoryControllerFactory implements Factory
 
         if ($id) {
             // Ensure we read from the draft stage at this position
-            $originalStage = Versioned::get_stage();
-            Versioned::set_stage(Versioned::DRAFT);
-            $page = SiteTree::get()->byID($id);
-            Versioned::set_stage($originalStage);
+            $page = Versioned::get_one_by_stage(
+                SiteTree::class,
+                Versioned::DRAFT,
+                sprintf('"SiteTree"."ID" = \'%d\'', $id)
+            );
 
             if ($page && $this->isEnabled($page)) {
                 return Injector::inst()->create(CMSPageHistoryViewerController::class);

--- a/tests/Controllers/HistoryControllerFactoryTest.php
+++ b/tests/Controllers/HistoryControllerFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace SilverStripe\VersionedAdmin\Tests\Controllers;
+
+use SilverStripe\VersionedAdmin\Tests\Controller\HistoryControllerFactory\HistoryControllerFactoryExtension;
+use SilverStripe\CMS\Controllers\CMSPageHistoryController;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController;
+use SilverStripe\VersionedAdmin\Controllers\HistoryControllerFactory;
+
+class HistoryControllerFactoryTest extends SapphireTest
+{
+    protected static $fixture_file = 'HistoryControllerFactoryTest.yml';
+
+    protected static $illegal_extensions = [
+        HistoryControllerFactory::class => '*'
+    ];
+
+    protected static $required_extensions = [
+        HistoryControllerFactory::class => [HistoryControllerFactoryExtension::class]
+    ];
+
+    public function testCreateController()
+    {
+        $factory = new HistoryControllerFactory;
+
+        $controller = $factory->create(null);
+        $this->assertInstanceOf(CMSPageHistoryController::class, $controller);
+
+        $id = $this->idFromFixture(SiteTree::class, 'page_one');
+
+        $mockRequest = new HTTPRequest('GET', '');
+        $mockRequest->setRouteParams(['ID' => $id]);
+        Injector::inst()->registerService($mockRequest);
+
+        $controller = $factory->create(null);
+        $this->assertInstanceOf(CMSPageHistoryController::class, $controller);
+
+        $id = $this->idFromFixture(SiteTree::class, 'page_two');
+
+        $mockRequest = new HTTPRequest('GET', '');
+        $mockRequest->setRouteParams(['ID' => $id]);
+        Injector::inst()->registerService($mockRequest);
+
+        $controller = $factory->create(null);
+        $this->assertInstanceOf(CMSPageHistoryViewerController::class, $controller);
+    }
+}

--- a/tests/Controllers/HistoryControllerFactoryTest.yml
+++ b/tests/Controllers/HistoryControllerFactoryTest.yml
@@ -1,0 +1,9 @@
+SilverStripe\CMS\Model\SiteTree:
+  page_one:
+    Title: 1
+    URLSegment: page-one
+    Content: <p>Hello world!</p>
+  page_two:
+    Title: 2
+    URLSegment: page-two
+    Content: <p>Hello world!</p>

--- a/tests/Controllers/HistoryControllerFactoryTest/HistoryControllerFactoryExtension.php
+++ b/tests/Controllers/HistoryControllerFactoryTest/HistoryControllerFactoryExtension.php
@@ -1,0 +1,14 @@
+<?php
+namespace SilverStripe\VersionedAdmin\Tests\Controller\HistoryControllerFactory;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class HistoryControllerFactoryExtension extends Extension implements TestOnly
+{
+    public function updateIsEnabled($record)
+    {
+        // Only "enable" for the second fixture (from HistoryControllerFactoryTest.yml)
+        return $record->Title === '2';
+    }
+}


### PR DESCRIPTION
I had trouble reproducing this using the steps that @Cheddam provided but I managed to reproduce it consistently with a test (that I've added to this commit). Yay for TDD!

Resolves #51 