### PR TITLE
FIX Check ID is numeric before using it

### DIFF
--- a/src/Controllers/HistoryControllerFactory.php
+++ b/src/Controllers/HistoryControllerFactory.php
@@ -27,7 +27,7 @@ class HistoryControllerFactory implements Factory
         $request = Injector::inst()->get(HTTPRequest::class);
         $id = $request->param('ID');
 
-        if ($id) {
+        if ($id && is_numeric($id)) {
             // Ensure we read from the draft stage at this position
             $originalStage = Versioned::get_stage();
             Versioned::set_stage(Versioned::DRAFT);


### PR DESCRIPTION
This fixes a bug surfacing in reports in elemental when using Postgres
where a FQCN is passed as the ID instead (from LeftAndMain::getCombinedClientConfig)