### PR TITLE
Archive add missing tab logic, fix file list

### DIFF
--- a/src/ArchiveAdmin.php
+++ b/src/ArchiveAdmin.php
@@ -62,11 +62,12 @@ class ArchiveAdmin extends ModelAdmin
      */
     public function getEditForm($id = null, $fields = null)
     {
-        $fields = new FieldList();
+        $fields = FieldList::create();
         $modelClass = $this->request->getVar('others') ? 'others' : $this->modelClass;
+        $classInst = Injector::inst()->get($this->modelClass);
 
-        if (ClassInfo::hasMethod(Injector::inst()->get($this->modelClass), 'getArchiveField')) {
-            $listField = Injector::inst()->get($this->modelClass)->getArchiveField();
+        if (ClassInfo::hasMethod($classInst, 'getArchiveField')) {
+            $listField = $classInst->getArchiveField();
             $fields->push($listField);
         } else {
             $otherVersionedObjects = $this->getVersionedModels('other');
@@ -290,14 +291,15 @@ class ArchiveAdmin extends ModelAdmin
      */
     public function getManagedModelTabs()
     {
-        $forms = new ArrayList();
-
+        $forms = ArrayList::create();
         $mainModels = $this->getVersionedModels('main', true);
+
         foreach ($mainModels as $class => $title) {
-            if (ClassInfo::hasMethod(Injector::inst()->get($class), 'isArchiveFieldEnabled')
-                && Injector::inst()->get($class)->isArchiveFieldEnabled()
+            $classInst = Injector::inst()->get($class);
+            if (ClassInfo::hasMethod($classInst, 'isArchiveFieldEnabled')
+                && $classInst->isArchiveFieldEnabled()
             ) {
-                $forms->push(new ArrayData([
+                $forms->push(ArrayData::create([
                     'Title' => $title,
                     'ClassName' => $class,
                     'Link' => $this->Link($this->sanitiseClassName($class)),
@@ -312,7 +314,7 @@ class ArchiveAdmin extends ModelAdmin
                 $this->request->getVar('others') !== null ||
                 array_key_exists($this->modelClass, $otherModels)
             );
-            $forms->push(new ArrayData([
+            $forms->push(ArrayData::create([
                 'Title' => _t(__CLASS__ . '.TAB_OTHERS', 'Others'),
                 'ClassName' => 'Others',
                 'Link' => $this->Link('?others=1'),

--- a/src/Extensions/FileArchiveExtension.php
+++ b/src/Extensions/FileArchiveExtension.php
@@ -31,6 +31,13 @@ class FileArchiveExtension extends DataExtension implements ArchiveViewProvider
     {
         $listField = ArchiveAdmin::createArchiveGridField('Files', File::class);
 
+        $list = $listField->getList();
+        // Paginator reports all records even if some can't be viewed, so we filter them out here
+        $list = $list->filterByCallback(function ($item) {
+            return $item->canView();
+        });
+        $listField->setList($list);
+
         $listColumns = $listField->getConfig()->getComponentByType(GridFieldDataColumns::class);
         $listColumns->setDisplayFields([
             'Name' => File::singleton()->fieldLabel('Name'),


### PR DESCRIPTION
This fixes a couple of small issues in archive admin:

1. `ArchiveViewProvider` had an `isArchiveFieldEnabled` function for determining if a given archive view should be presented as a tab in 'Archives' – currently uses for 'Files' archive tab to only show if the setting for assets to be retained when deleted is set. This function wasn't actually leveraged by ArchiveAdmin so has been added.

2. There was an issue with the files gridfield showing the count for records that weren't displayed due to canView permissions, so we do that check sooner so the paginator and page count report the correct count.