### PR TITLE
Remove classes of disabled archive providers

### DIFF
--- a/src/ArchiveAdmin.php
+++ b/src/ArchiveAdmin.php
@@ -191,9 +191,37 @@ class ArchiveAdmin extends ModelAdmin
             }
         );
 
+        $archiveProviders = ClassInfo::implementorsOf(ArchiveViewProvider::class);
+
+        // Get providers that have their view disabled
+        $disabledProviders = array_filter(
+            $archiveProviders,
+            function ($provider) {
+                return !Injector::inst()->get($provider)->isArchiveFieldEnabled();
+            }
+        );
+
+        $disabledProvidersClasses = [];
+
+        // Get the classes that are declared as handled by the disabled providers
+        foreach ($disabledProviders as $provider) {
+            $disabledProviderClass = Injector::inst()->get($provider)->getArchiveFieldClass();
+            $disabledProvidersClasses[] = $disabledProviderClass;
+        }
+
+        $disabledHandledClasses = [];
+        foreach ($disabledProvidersClasses as $disabledProviderClass) {
+            $disabledHandledClasses = array_merge(
+                $disabledHandledClasses,
+                array_keys(ClassInfo::subclassesFor($disabledProviderClass))
+            );
+        }
+
+        // Remove any subclasses that would also be handled by those disabled providers
+        $versionedClasses = array_diff_key($versionedClasses, array_flip($disabledHandledClasses));
+
         // If there is a valid filter passed
         if ($filter && in_array($filter, ['main', 'other'])) {
-            $archiveProviders = ClassInfo::implementorsOf(ArchiveViewProvider::class);
             $archiveProviderClasses = [];
 
             // Get the classes that are decalred as handled by ArchiveViewProviders


### PR DESCRIPTION
Fixes silverstripe/silverstripe-framework#8531, silverstripe/silverstripe-framework#8532

Fixes the Archive Admin defaulting to showing a GridField of a disabled archive view provider, in this case Files, as the classes were still being included in the list even though their tabs were removed/hidden.