### PR TITLE
FIX Ensure HistoryViewerController has priority over CMSPageHistoryController

### DIFF
--- a/src/Controllers/CMSPageHistoryViewerController.php
+++ b/src/Controllers/CMSPageHistoryViewerController.php
@@ -24,7 +24,12 @@ class CMSPageHistoryViewerController extends CMSMain
 
     private static $url_rule = '/$Action/$ID/$VersionID/$OtherVersionID';
 
-    private static $url_priority = 41;
+    /**
+     * {@inheritDoc}
+     *
+     * This is one higher than CMSPageHistoryController to give it priority
+     */
+    private static $url_priority = 43;
 
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 


### PR DESCRIPTION
The url_priority was set lower than the CMS controller so it wouldn't take precedence in SS 4.2. Now that it's the default in SS 4.3 it should be higher - I'm not sure why this isn't always the case, but it's something I noticed while working on a large project recently.

I've added a doc block explaining why so it doesn't look like a magic number.