### PR TITLE
Update phpcs to use PSR-12 (with exclusions) and run automated linting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7",
-        "squizlabs/php_codesniffer": "3.x-dev",
+        "squizlabs/php_codesniffer": "^3",
         "silverstripe/cms": "^5@dev"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7",
-        "squizlabs/php_codesniffer": "^3",
+        "squizlabs/php_codesniffer": "3.x-dev",
         "silverstripe/cms": "^5@dev"
     },
     "scripts": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,8 +2,8 @@
 <ruleset name="SilverStripe">
     <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
 
-    <!-- base rules are PSR-2 -->
-    <rule ref="PSR2" >
+    <!-- base rules are PSR-12 -->
+    <rule ref="PSR12" >
         <!-- Current exclusions -->
         <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />

--- a/src/ArchiveAdmin.php
+++ b/src/ArchiveAdmin.php
@@ -105,7 +105,7 @@ class ArchiveAdmin extends ModelAdmin
         $form->setTemplate($this->getTemplatesWithSuffix('_EditForm'));
         $form->setAttribute('data-pjax-fragment', 'CurrentForm');
         $form->addExtraClass(
-            'ArchiveAdmin discardchanges cms-edit-form cms-panel-padded center flexbox-area-grow '.
+            'ArchiveAdmin discardchanges cms-edit-form cms-panel-padded center flexbox-area-grow ' .
             $this->BaseCSSClasses()
         );
         $form->setFormAction(Controller::join_links(
@@ -130,10 +130,10 @@ class ArchiveAdmin extends ModelAdmin
         $config = GridFieldConfig_Base::create();
         $config->removeComponentsByType(VersionedGridFieldState::class);
         $config->removeComponentsByType(GridFieldFilterHeader::class);
-        $config->addComponent(new GridFieldDetailForm);
-        $config->addComponent(new GridFieldViewButton);
-        $config->addComponent(new GridFieldRestoreAction);
-        $config->addComponent(new GridField_ActionMenu);
+        $config->addComponent(new GridFieldDetailForm());
+        $config->addComponent(new GridFieldViewButton());
+        $config->addComponent(new GridFieldRestoreAction());
+        $config->addComponent(new GridField_ActionMenu());
 
         $list = singleton($class)->get();
         $baseTable = singleton($list->dataClass())->baseTable();

--- a/src/Controllers/HistoryViewerController.php
+++ b/src/Controllers/HistoryViewerController.php
@@ -170,7 +170,7 @@ class HistoryViewerController extends LeftAndMain
 
         if (!$record->canView()) {
             $this->jsonError(403, _t(
-                __CLASS__.'.ErrorItemViewPermissionDenied',
+                __CLASS__ . '.ErrorItemViewPermissionDenied',
                 "You don't have the necessary permissions to view {ObjectTitle}",
                 ['ObjectTitle' => $record->i18n_singular_name()]
             ));

--- a/tests/Controllers/HistoryControllerFactoryTest.php
+++ b/tests/Controllers/HistoryControllerFactoryTest.php
@@ -24,7 +24,7 @@ class HistoryControllerFactoryTest extends SapphireTest
 
     public function testCreateController()
     {
-        $factory = new HistoryControllerFactory;
+        $factory = new HistoryControllerFactory();
 
         $controller = $factory->create(null);
         $this->assertInstanceOf(CMSPageHistoryViewerController::class, $controller);


### PR DESCRIPTION
Still has some exclusions which would require core API changes, this is updating Travis to use PSR-12 (unstable at this point) and running automated linting

Issue: https://github.com/silverstripe/silverstripe-framework/issues/7991