### PR TITLE
Add missing implement TestOnly in ViewProviderVersionedObject - unit tests failing.

### DIFF
--- a/tests/ArchiveAdminTest/ViewProviderVersionedObject.php
+++ b/tests/ArchiveAdminTest/ViewProviderVersionedObject.php
@@ -7,7 +7,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\VersionedAdmin\Interfaces\ArchiveViewProvider;
 
-class ViewProviderVersionedObject extends DataObject implements ArchiveViewProvider
+class ViewProviderVersionedObject extends DataObject implements ArchiveViewProvider, TestOnly
 {
     private static $table_name = 'Test_ViewProviderVersionedObject';
 


### PR DESCRIPTION
**Versions** 
Framework: 4.3.0
versioned-admin: 1.1

I can replicate this only in CircleCI. Not sure why it's not breaking in my local.
Please back fix this into v1.1 as well. 

**Circle CI error**
Fatal error: Maximum function nesting level of '256' reached, aborting! in /var/www/html/vendor/silverstripe/framework/src/ORM/Connect/MySQLiConnector.php on line 49

**Actual PHP Error**

Fatal error: Uncaught SilverStripe\ORM\Connect\DatabaseException: Couldn't run query:

CREATE  TABLE "SilverStripe_VersionedAdmin_Tests_ArchiveAdminTest_ViewProviderVersionedObject" (
				"ID" int(11) not null auto_increment,
"ClassName" enum('SilverStripe\\VersionedAdmin\\Tests\\ArchiveAdminTest\\ViewProviderVersionedObject','SilverStripe\\VersionedAdmin\\Tests\\ArchiveAdminTest\\ViewProviderChildObject') character set utf8 collate utf8_general_ci default 'SilverStripe\\VersionedAdmin\\Tests\\ArchiveAdminTest\\ViewProviderVersionedObject',
"LastEdited" datetime,
"Created" datetime,

				index "ClassName" ("ClassName"),

				primary key (ID)
			) ENGINE=InnoDB

Identifier name 'SilverStripe_VersionedAdmin_Tests_ArchiveAdminTest_ViewProviderVersionedObject' is too long in /var/www/html/vendor/silverstripe/framework/src/ORM/Connect/DBConnector.php on line 64

