### PR TITLE
NEW Allow fetching history from schema by date rather than version

### DIFF
--- a/tests/Controllers/HistoryViewerControllerTest.php
+++ b/tests/Controllers/HistoryViewerControllerTest.php
@@ -42,6 +42,7 @@ class HistoryViewerControllerTest extends SapphireTest
             'RecordClass' => 'Page',
             'RecordID' => 123,
             'RecordVersion' => 234,
+            'RecordDate' => null
         ]);
 
         $controllerMock->expects($this->once())->method('getCompareForm')->with([


### PR DESCRIPTION
This is a "NEW" but is actually data integrity fix. Currently fetching a record by version number doesn't necessarily give you accurate information for related objects in history. Fetching the dataobject using archive mode set to a date is more accurate.