### PR TITLE
Remove CMS requirement from ArchiveAdmin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 before_install:
  - sudo apt-get update
  - sudo apt-get install chromium-chromedriver

--- a/src/ArchiveAdmin.php
+++ b/src/ArchiveAdmin.php
@@ -50,8 +50,6 @@ class ArchiveAdmin extends ModelAdmin
 
         Requirements::javascript('silverstripe/versioned-admin:client/dist/js/bundle.js');
         Requirements::css('silverstripe/versioned-admin:client/dist/styles/bundle.css');
-        Requirements::javascript('silverstripe/cms: client/dist/js/bundle.js');
-        Requirements::css('silverstripe/cms: client/dist/styles/bundle.css');
     }
 
     /**


### PR DESCRIPTION
See issue #102 ArchiveAdmin appears to require CMS JS/CSS but apparently doesn't need them.

I have done this on branch 1.1 as this appears to be the earliest point `ArchiveAdmin` exists.