### PR TITLE
FIX Use a more reliable method of including client bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 before_install:
  - sudo apt-get update
  - sudo apt-get install chromium-chromedriver

--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -10,3 +10,9 @@ SilverStripe\Core\Injector\Injector:
 SilverStripe\CMS\Controllers\CMSMain:
   extensions:
     - SilverStripe\VersionedAdmin\Extensions\CMSMainExtension
+
+SilverStripe\Admin\LeftAndMain:
+  extra_requirements_javascript:
+    - 'silverstripe/versioned-admin:client/dist/js/bundle.js'
+  extra_requirements_css:
+    - 'silverstripe/versioned-admin:client/dist/styles/bundle.css'

--- a/src/ArchiveAdmin.php
+++ b/src/ArchiveAdmin.php
@@ -19,13 +19,11 @@ use SilverStripe\Forms\GridField\GridFieldViewButton;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
-use SilverStripe\Security\Member;
 use SilverStripe\Versioned\GridFieldRestoreAction;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Versioned\VersionedGridFieldState\VersionedGridFieldState;
 use SilverStripe\VersionedAdmin\Interfaces\ArchiveViewProvider;
 use SilverStripe\View\ArrayData;
-use SilverStripe\View\Requirements;
 
 /**
  * Archive admin is a section of the CMS that displays archived records
@@ -47,11 +45,6 @@ class ArchiveAdmin extends ModelAdmin
     protected function init()
     {
         parent::init();
-
-        Requirements::javascript('silverstripe/versioned-admin:client/dist/js/bundle.js');
-        Requirements::css('silverstripe/versioned-admin:client/dist/styles/bundle.css');
-        Requirements::javascript('silverstripe/cms: client/dist/js/bundle.js');
-        Requirements::css('silverstripe/cms: client/dist/styles/bundle.css');
     }
 
     /**

--- a/src/Extensions/CMSMainExtension.php
+++ b/src/Extensions/CMSMainExtension.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\VersionedAdmin\Extensions;
 
 use SilverStripe\Core\Extension;
-use SilverStripe\View\Requirements;
 
 /**
  * @deprecated 1.2 This extension no longer serves a purpose. Write a standalone extensions instead.

--- a/src/Extensions/CMSMainExtension.php
+++ b/src/Extensions/CMSMainExtension.php
@@ -5,7 +5,7 @@ namespace SilverStripe\VersionedAdmin\Extensions;
 use SilverStripe\Core\Extension;
 
 /**
- * @deprecated 1.2 This extension no longer serves a purpose. Write a standalone extensions instead.
+ * @deprecated 1.2.0 This extension no longer serves a purpose. Write a standalone extensions instead.
  */
 class CMSMainExtension extends Extension
 {

--- a/src/Extensions/CMSMainExtension.php
+++ b/src/Extensions/CMSMainExtension.php
@@ -5,15 +5,12 @@ namespace SilverStripe\VersionedAdmin\Extensions;
 use SilverStripe\Core\Extension;
 use SilverStripe\View\Requirements;
 
+/**
+ * @deprecated 1.2 This extension no longer serves a purpose. Write a standalone extensions instead.
+ */
 class CMSMainExtension extends Extension
 {
-    /**
-     * Inject the history viewer client requirements whenever accessing a CMS controller, ensuring
-     * that they're always available for when the JS injector requires them
-     */
     public function init()
     {
-        Requirements::javascript('silverstripe/versioned-admin:client/dist/js/bundle.js');
-        Requirements::css('silverstripe/versioned-admin:client/dist/styles/bundle.css');
     }
 }

--- a/src/Forms/HistoryViewerField.php
+++ b/src/Forms/HistoryViewerField.php
@@ -2,11 +2,9 @@
 
 namespace SilverStripe\VersionedAdmin\Forms;
 
-use SilverStripe\Core\Convert;
 use SilverStripe\Forms\FormField;
 use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\View\Requirements;
 
 class HistoryViewerField extends FormField
 {

--- a/src/Forms/HistoryViewerField.php
+++ b/src/Forms/HistoryViewerField.php
@@ -31,9 +31,6 @@ class HistoryViewerField extends FormField
 
     public function __construct($name, $title = null, $value = null)
     {
-        Requirements::javascript('silverstripe/versioned-admin:client/dist/js/bundle.js');
-        Requirements::css('silverstripe/versioned-admin:client/dist/styles/bundle.css');
-
         parent::__construct($name, $title, $value);
     }
 

--- a/tests/Forms/HistoryViewerFieldTest.php
+++ b/tests/Forms/HistoryViewerFieldTest.php
@@ -5,23 +5,9 @@ namespace SilverStripe\VersionedAdmin\Tests\Forms;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\Form;
 use SilverStripe\VersionedAdmin\Forms\HistoryViewerField;
-use SilverStripe\View\Requirements;
 
 class HistoryViewerFieldTest extends SapphireTest
 {
-    public function testRequirementsAreAddedInConstructor()
-    {
-        new HistoryViewerField('Test');
-
-        $css = Requirements::backend()->getCSS();
-        $this->assertNotEmpty($css);
-        $this->assertContains('client/dist/styles/bundle.css', key($css));
-
-        $javascript = Requirements::backend()->getJavascript();
-        $this->assertNotEmpty($javascript);
-        $this->assertContains('client/dist/js/bundle.js', key($javascript));
-    }
-
     public function testGetSourceRecord()
     {
         $form = $this->createMock(Form::class);


### PR DESCRIPTION
The extension that provided this config was only applying to CMSMain which would not help history viewers that weren't loading outside of a CMS page context (eg. ModelAdmin). This PR makes the HistoryViewer JS apply more globally using a method similar to other modules that provide fields.