### PR TITLE
Changed "revert" button title when revert is possible.

### DIFF
--- a/client/src/components/HistoryViewer/HistoryViewerToolbar.js
+++ b/client/src/components/HistoryViewer/HistoryViewerToolbar.js
@@ -36,7 +36,7 @@ class HistoryViewerToolbar extends Component {
 
     const revertButtonTitle = isReverting
       ? i18n._t('HistoryViewerToolbar.REVERT_IN_PROGRESS', 'Revert in progress...')
-      : i18n._t('HistoryViewerToolbar.REVERT_UNAVAILABLE', 'Unavailable for the current version');
+      : (isLatestVersion ? i18n._t('HistoryViewerToolbar.REVERT_UNAVAILABLE', 'Unavailable for the current version') : '');
 
     return (
       <div className="toolbar toolbar--south">


### PR DESCRIPTION
If revert wasn't already in process, button was always showing 'Unavailable for the current version' message - both for the latest version (which clearly one can't revert to) and all other versions - where revert is possible.

Added a check should it display or not.