### PR TITLE
FIX Update core requirements to 4.5 series

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
         }
     ],
     "require": {
-        "silverstripe/admin": "^1.3",
-        "silverstripe/framework": "^4.3",
-        "silverstripe/versioned": "^1.3",
+        "silverstripe/admin": "^1.5",
+        "silverstripe/framework": "^4.5",
+        "silverstripe/versioned": "^1.5",
         "silverstripe/graphql": "^2.0 || ^3.0",
         "silverstripe/vendor-plugin": "^1"
     },
     "require-dev": {
         "phpunit/phpunit": "^5",
         "squizlabs/php_codesniffer": "^3",
-        "silverstripe/cms": "^4.2"
+        "silverstripe/cms": "^4.5"
     },
     "scripts": {
         "lint": "phpcs src/ tests/",


### PR DESCRIPTION
See [silverstripe-cms#2521](https://github.com/silverstripe/silverstripe-cms/issues/2521) for context.

(Note that versioned-admin 1.3.x tracks the 4.5 release line.)