### PR TITLE
FIX Reorder model tabs

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -7,6 +7,6 @@ en:
     COLUMN_TYPE: Type
     SELECT_EMPTY: Select…
     SELECT_TYPE: 'Select a content type'
-    TAB_OTHERS: Others
+    TAB_OTHERS: Other
   SilverStripe\VersionedAdmin\Controllers\HistoryViewerController:
     ErrorItemViewPermissionDenied: 'You don''t have the necessary permissions to view {ObjectTitle}'


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-versioned/issues/207

You can get the Files tab to easily show by return true from `FileArchiveExtension::isArchiveFieldEnabled()`

(most installations will probably have this set to false and won't show the Files tab)

Default tab is selected

Before
![image](https://user-images.githubusercontent.com/4809037/90218334-a2055180-de57-11ea-8510-dc79d63554f3.png)

After
![image](https://user-images.githubusercontent.com/4809037/90218005-d2002500-de56-11ea-85ea-53ad5fcdebe2.png)
