### PR TITLE
FIX Prevent exception when parent does not have breadcrumbs

### DIFF
--- a/src/Extensions/BlockArchiveExtension.php
+++ b/src/Extensions/BlockArchiveExtension.php
@@ -48,7 +48,7 @@ class BlockArchiveExtension extends DataExtension implements ArchiveViewProvider
             'Breadcrumbs' => function ($val, $item) {
                 $parent = $item->Page;
 
-                return $parent ? $parent->Breadcrumbs() : null;
+                return ($parent && $parent->hasMethod('Breadcrumbs')) ? $parent->Breadcrumbs() : null;
             },
             'allVersions.first.LastEdited' => function ($val, $item) {
                 return DBDatetime::create_field('Datetime', $val)->Ago();


### PR DESCRIPTION
Fix for https://github.com/silverstripe/silverstripe-versioned-admin/issues/118

PR was originally https://github.com/silverstripe/silverstripe-versioned-admin/pull/141, though that was based from and targeting `master` instead of `1.6` - seemed easier to just redo and put down Co-authors in the commit message

Have replicated issue and tested locally that the solution in the original PR works correctly

Co-authored-by: Kong Jin Jie <jinjie@swiftdev.sg>
Co-authored-by: Robbie Averill <robbie@averill.co.nz>