### PR TITLE
DOCS include userhelp link in versioned-admin readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ $ composer require silverstripe/versioned-admin
 
 ## Documentation
 
-See ["Versioning" on docs.silverstripe.org](https://docs.silverstripe.org/en/4/developer_guides/model/versioning/)
+For Developer documentation see ["Versioning" on docs.silverstripe.org](https://docs.silverstripe.org/en/4/developer_guides/model/versioning/)
+
+For CMS User help see ["Using history" on userhelp.silverstripe.org](https://userhelp.silverstripe.org/en/4/optional_features/content_blocks/history/)
 
 ## Versioning
 


### PR DESCRIPTION
Resolves https://github.com/silverstripe/silverstripe-versioned-admin/issues/121

I figure if someone wants to see screenshots and features included in the module the CMS User help would be a good source of truth. I've noted there's not really a consistent way of doing this for core modules but thought I'd raise this incase it's useful.