### PR TITLE
BUG Fix issue with composer warning about PSR-4 paths

### DIFF
--- a/tests/Controllers/HistoryControllerFactoryTest.php
+++ b/tests/Controllers/HistoryControllerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace SilverStripe\VersionedAdmin\Tests\Controllers;
 
-use SilverStripe\VersionedAdmin\Tests\Controller\HistoryControllerFactory\HistoryControllerFactoryExtension;
+use SilverStripe\VersionedAdmin\Tests\Controllers\HistoryControllerFactory\HistoryControllerFactoryExtension;
 use SilverStripe\CMS\Controllers\CMSPageHistoryController;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\HTTPRequest;

--- a/tests/Controllers/HistoryControllerFactoryTest/HistoryControllerFactoryExtension.php
+++ b/tests/Controllers/HistoryControllerFactoryTest/HistoryControllerFactoryExtension.php
@@ -1,5 +1,5 @@
 <?php
-namespace SilverStripe\VersionedAdmin\Tests\Controller\HistoryControllerFactory;
+namespace SilverStripe\VersionedAdmin\Tests\Controllers\HistoryControllerFactory;
 
 use SilverStripe\Core\Extension;
 use SilverStripe\Dev\TestOnly;


### PR DESCRIPTION
Fixes a super minor issue

> Deprecation Notice: Class SilverStripe\VersionedAdmin\Tests\Controller\HistoryControllerFactory\HistoryControllerFactoryExtension located in ./vendor/silverstripe/versioned-admin/tests/Controllers/HistoryControllerFactoryTest/HistoryControllerFactoryExtension.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///opt/bitnami/php/bin/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201
