### PR TITLE
BUG don't disable bundle.js / bundle.css with no-cms install

### DIFF
--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -11,8 +11,3 @@ SilverStripe\CMS\Controllers\CMSMain:
   extensions:
     - SilverStripe\VersionedAdmin\Extensions\CMSMainExtension
 
-SilverStripe\Admin\LeftAndMain:
-  extra_requirements_javascript:
-    - 'silverstripe/versioned-admin:client/dist/js/bundle.js'
-  extra_requirements_css:
-    - 'silverstripe/versioned-admin:client/dist/styles/bundle.css'

--- a/_config/requirements.yml
+++ b/_config/requirements.yml
@@ -1,0 +1,8 @@
+---
+Name: versionedadminrequirements
+---
+SilverStripe\Admin\LeftAndMain:
+  extra_requirements_javascript:
+    - 'silverstripe/versioned-admin:client/dist/js/bundle.js'
+  extra_requirements_css:
+    - 'silverstripe/versioned-admin:client/dist/styles/bundle.css'


### PR DESCRIPTION
If installed in a framework-only installation, the missing JS and CSS causes the interface to break. This fix ensures that the dependencies are always loaded.

Fixes #183