### PR TITLE
FIX Avoid attempting to diff object-based field values

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -14,3 +14,5 @@ en:
   SilverStripe\VersionedAdmin\Controllers\HistoryViewerController:
     ErrorItemViewPermissionDenied: "You don't have the necessary permissions to view {ObjectTitle}"
     MENUTITLE: SilverStripe\VersionedAdmin\Controllers\HistoryViewerController
+  Silverstripe\VersionedAdmin\Forms\DiffField:
+    NO_DIFF_AVAILABLE: 'No diff available'

--- a/src/Forms/DiffField.php
+++ b/src/Forms/DiffField.php
@@ -44,6 +44,12 @@ class DiffField extends HTMLReadonlyField
     {
         $oldValue = $this->getOutdatedField()->Value();
         $newValue = $this->getComparisonField()->Value();
+
+        // Objects can't be diffed
+        if (is_object($oldValue) || is_object($newValue)) {
+            return sprintf('(%s)', _t(__CLASS__ . '.NO_DIFF_AVAILABLE', 'No diff available'));
+        }
+
         return Diff::compareHTML($oldValue, $newValue);
     }
 

--- a/tests/Forms/DiffFieldTest.php
+++ b/tests/Forms/DiffFieldTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Forms;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\TextField;
+use SilverStripe\Forms\TreeMultiselectField;
+use SilverStripe\ORM\ManyManyList;
+use SilverStripe\Security\Group;
+use SilverStripe\VersionedAdmin\Forms\DiffField;
+
+class DiffFieldTest extends SapphireTest
+{
+    public function testScalarValuesAreDiffed()
+    {
+        $newField = TextField::create('Test', 'Test', 'new');
+        $diffField = DiffField::create('DiffTest');
+
+        $diffField->setComparisonField($newField);
+        $diffField->setValue('old');
+
+        $this->assertEquals('<ins>new</ins> <del>old</del>', $diffField->Value());
+    }
+
+    /**
+     * Relationship lists and other non-scalar field values cannot be diffed in the current incarnation of DiffField.
+     */
+    public function testObjectValuesAreNotDiffed()
+    {
+        $newField = TreeMultiselectField::create('Test', 'Test');
+        $diffField = DiffField::create('DiffTest');
+
+        $diffField->setComparisonField($newField);
+        $diffField->setValue(ManyManyList::create(Group::class, 'Group_Members', 'GroupID', 'MemberID'));
+
+        $this->assertEquals('(No diff available)', $diffField->Value());
+    }
+}


### PR DESCRIPTION
In particular, this stops TreeMultiselectField values from breaking the comparison UI.

A more in-depth fix would introduce support for diffing these values, but there are multiple issues to address before this can be implemented, such as DiffField not honoring custom setValue methods on FormField sub-classes.

Fixes silverstripe/silverstripe-framework#9843.
Fixes silverstripe/silverstripe-framework#9839.