### PR TITLE
Fix missing dutch language title for ArchiveAdmin

### DIFF
--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -5,12 +5,12 @@ nl:
     COLUMN_ORIGIN: Oorsprong
     COLUMN_TITLE: Titel
     COLUMN_TYPE: Type
-    MENUTITLE: ''
+    MENUTITLE: 'Archief'
     SELECT_EMPTY: Selecteer...
     SELECT_TYPE: 'Selecteer type'
-    TAB_OTHERS: ''
+    TAB_OTHERS: 'Andere'
   SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController:
-    MENUTITLE: ''
+    MENUTITLE: 'Geschiedenis'
   SilverStripe\VersionedAdmin\Controllers\HistoryViewerController:
     ErrorItemViewPermissionDenied: 'Je hebt geen toestemming om {ObjectTitle} te bekijken.'
-    MENUTITLE: ''
+    MENUTITLE: SilverStripe\VersionedAdmin\Controllers\HistoryViewerController


### PR DESCRIPTION
In the CMS the archives admin does not have a title in some languages. In my case NL dutch.
Note: since last update other languages have this issue too. Perhaps someone can add the other language translations.
Commit causing issue:
https://github.com/silverstripe/silverstripe-versioned-admin/commit/c320a788a6b88d1d655eb7555b31a328922b6226