### PR TITLE
Rescue Master Branch commit: FIX Replace references to deprecated allVersions()

### DIFF
--- a/src/ArchiveAdmin.php
+++ b/src/ArchiveAdmin.php
@@ -86,11 +86,11 @@ class ArchiveAdmin extends ModelAdmin
                 $listColumns = $listField->getConfig()->getComponentByType(GridFieldDataColumns::class);
                 $listColumns->setDisplayFields([
                     'Title' => _t(__CLASS__ . '.COLUMN_TITLE', 'Title'),
-                    'allVersions.first.LastEdited' => _t(__CLASS__ . '.COLUMN_DATEARCHIVED', 'Date Archived'),
-                    'allVersions.first.Author.Name' => _t(__CLASS__ . '.COLUMN_ARCHIVEDBY', 'Archived By'),
+                    'Versions.first.LastEdited' => _t(__CLASS__ . '.COLUMN_DATEARCHIVED', 'Date Archived'),
+                    'Versions.first.Author.Name' => _t(__CLASS__ . '.COLUMN_ARCHIVEDBY', 'Archived By'),
                 ]);
                 $listColumns->setFieldFormatting([
-                    'allVersions.first.LastEdited' => function ($val, $item) {
+                    'Versions.first.LastEdited' => function ($val, $item) {
                         return DBDatetime::create_field('Datetime', $val)->Ago();
                     },
                 ]);

--- a/src/Extensions/BlockArchiveExtension.php
+++ b/src/Extensions/BlockArchiveExtension.php
@@ -34,12 +34,12 @@ class BlockArchiveExtension extends DataExtension implements ArchiveViewProvider
         $listColumns->setDisplayFields([
             'Title' => BaseElement::singleton()->fieldLabel('Title'),
             'Type' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_TYPE', 'Type'),
-            'allVersions.first.LastEdited' => _t(
+            'Versions.first.LastEdited' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_DATEARCHIVED',
                 'Date Archived'
             ),
             'Breadcrumbs' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ORIGIN', 'Origin'),
-            'allVersions.first.Author.Name' => _t(
+            'Versions.first.Author.Name' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ARCHIVEDBY',
                 'Archived By'
             )
@@ -50,7 +50,7 @@ class BlockArchiveExtension extends DataExtension implements ArchiveViewProvider
 
                 return ($parent && $parent->hasMethod('Breadcrumbs')) ? $parent->Breadcrumbs() : null;
             },
-            'allVersions.first.LastEdited' => function ($val, $item) {
+            'Versions.first.LastEdited' => function ($val, $item) {
                 return DBDatetime::create_field('Datetime', $val)->Ago();
             },
         ]);

--- a/src/Extensions/FileArchiveExtension.php
+++ b/src/Extensions/FileArchiveExtension.php
@@ -47,12 +47,12 @@ class FileArchiveExtension extends DataExtension implements ArchiveViewProvider
         $listColumns->setDisplayFields([
             'Name' => File::singleton()->fieldLabel('Name'),
             'appCategory' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_TYPE', 'Type'),
-            'allVersions.first.LastEdited' => _t(
+            'Versions.first.LastEdited' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_DATEARCHIVED',
                 'Date Archived'
             ),
             'Parent.Name' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ORIGIN', 'Origin'),
-            'allVersions.first.Author.Name' => _t(
+            'Versions.first.Author.Name' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ARCHIVEDBY',
                 'Archived By'
             )
@@ -61,7 +61,7 @@ class FileArchiveExtension extends DataExtension implements ArchiveViewProvider
             'appCategory' => function ($val, $item) {
                 return ucfirst($val ?: $item->i18n_singular_name());
             },
-            'allVersions.first.LastEdited' => function ($val, $item) {
+            'Versions.first.LastEdited' => function ($val, $item) {
                 return DBDatetime::create_field('Datetime', $val)->Ago();
             },
         ]);

--- a/src/Extensions/SiteTreeArchiveExtension.php
+++ b/src/Extensions/SiteTreeArchiveExtension.php
@@ -34,12 +34,12 @@ class SiteTreeArchiveExtension extends DataExtension implements ArchiveViewProvi
         $listColumns->setDisplayFields([
             'Title' => SiteTree::singleton()->fieldLabel('Title'),
             'i18n_singular_name' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_TYPE', 'Type'),
-            'allVersions.first.LastEdited' => _t(
+            'Versions.first.LastEdited' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_DATEARCHIVED',
                 'Date Archived'
             ),
             'ParentID' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ORIGIN', 'Origin'),
-            'allVersions.first.Author.Name' => _t(
+            'Versions.first.Author.Name' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ARCHIVEDBY',
                 'Archived By'
             )
@@ -55,7 +55,7 @@ class SiteTreeArchiveExtension extends DataExtension implements ArchiveViewProvi
                     return $breadcrumbString;
                 }
             },
-            'allVersions.first.LastEdited' => function ($val, $item) {
+            'Versions.first.LastEdited' => function ($val, $item) {
                 return DBDatetime::create_field('Datetime', $val)->Ago();
             },
         ]);


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-versioned-admin/commit/1b63f375e3a34694158ac47a86f8f34b02daf847

Targetting `1` to avoid deprecation warnings against core code.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350