### PR TITLE
API Migrate SilverStripeNagivator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ coverage/
 /**/*.css.map
 artifacts/
 coverage/
+/vendor/
+/_resources/
+composer.lock

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -16,3 +16,13 @@ en:
     MENUTITLE: SilverStripe\VersionedAdmin\Controllers\HistoryViewerController
   SilverStripe\VersionedAdmin\Forms\DiffField:
     NO_DIFF_AVAILABLE: 'No diff available'
+  SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink:
+    ARCHIVED_FROM: 'Archived site from {date}'
+    PREVIEW: 'Preview version'
+    TITLE: 'Archived'
+  SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_LiveLink:
+    PUBLISHED_SITE: 'Published Site'
+    TITLE: 'Published'
+  SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_StageLink:
+    DRAFT_SITE: 'Draft Site'
+    TITLE: 'Draft'

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,5 +10,6 @@
         <!-- Current exclusions -->
         <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
     </rule>
 </ruleset>

--- a/src/Navigator/SilverStripeNavigatorItem_ArchiveLink.php
+++ b/src/Navigator/SilverStripeNavigatorItem_ArchiveLink.php
@@ -39,7 +39,10 @@ class SilverStripeNavigatorItem_ArchiveLink extends SilverStripeNavigatorItem
         }
         /** @var DBDatetime $dateObj */
         $dateObj = DBField::create_field('Datetime', $date);
-        $title = _t(SilverStripeNavigatorItem::class . '.WONT_BE_SHOWN', 'Note: this message will not be shown to your visitors');
+        $title = _t(
+            SilverStripeNavigatorItem::class . '.WONT_BE_SHOWN',
+            'Note: this message will not be shown to your visitors'
+        );
         return "<div id=\"SilverStripeNavigatorMessage\" title=\"{$title}\">"
             . _t(__CLASS__ . '.ARCHIVED_FROM', 'Archived site from {date}', ['date' => $dateObj->Nice()])
             . '</div>';

--- a/src/Navigator/SilverStripeNavigatorItem_ArchiveLink.php
+++ b/src/Navigator/SilverStripeNavigatorItem_ArchiveLink.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Navigator;
+
+use SilverStripe\Admin\Navigator\SilverStripeNavigatorItem;
+use SilverStripe\CMS\Model\RedirectorPage;
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Convert;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\Versioned\Versioned;
+
+class SilverStripeNavigatorItem_ArchiveLink extends SilverStripeNavigatorItem
+{
+    private static int $priority = 40;
+
+    public function getHTML()
+    {
+        $linkClass = $this->isActive() ? 'ss-ui-button current' : 'ss-ui-button';
+        $linkTitle = _t(__CLASS__ . '.PREVIEW', 'Preview version');
+        $recordLink = Convert::raw2att(Controller::join_links(
+            $this->record->AbsoluteLink(),
+            '?archiveDate=' . urlencode($this->record->LastEdited ?? '')
+        ));
+        return "<a class=\"{$linkClass}\" href=\"$recordLink\" target=\"_blank\">$linkTitle</a>";
+    }
+
+    public function getTitle()
+    {
+        return _t(__CLASS__ . '.TITLE', 'Archived');
+    }
+
+    public function getMessage()
+    {
+        $date = Versioned::current_archived_date();
+        if (empty($date)) {
+            return null;
+        }
+        /** @var DBDatetime $dateObj */
+        $dateObj = DBField::create_field('Datetime', $date);
+        $title = _t(SilverStripeNavigatorItem::class . '.WONT_BE_SHOWN', 'Note: this message will not be shown to your visitors');
+        return "<div id=\"SilverStripeNavigatorMessage\" title=\"{$title}\">"
+            . _t(__CLASS__ . '.ARCHIVED_FROM', 'Archived site from {date}', ['date' => $dateObj->Nice()])
+            . '</div>';
+    }
+
+    public function getLink()
+    {
+        $link = $this->record->PreviewLink();
+        return $link ? Controller::join_links($link, '?archiveDate=' . urlencode($this->record->LastEdited ?? '')) : '';
+    }
+
+    public function canView($member = null)
+    {
+        /** @var Versioned|DataObject $record */
+        $record = $this->record;
+        return (
+            $record->hasExtension(Versioned::class)
+            && $record->hasStages()
+            && $this->isArchived()
+            // Don't follow redirects in preview, they break the CMS editing form
+            && !($record instanceof RedirectorPage)
+            && $this->getLink()
+        );
+    }
+
+    public function isActive()
+    {
+        return $this->isArchived();
+    }
+}

--- a/src/Navigator/SilverStripeNavigatorItem_LiveLink.php
+++ b/src/Navigator/SilverStripeNavigatorItem_LiveLink.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Navigator;
+
+use SilverStripe\Admin\Navigator\SilverStripeNavigatorItem;
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Convert;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+class SilverStripeNavigatorItem_LiveLink extends SilverStripeNavigatorItem
+{
+    private static int $priority = 30;
+
+    public function getHTML()
+    {
+        $livePage = $this->getLivePage();
+        if (!$livePage) {
+            return null;
+        }
+
+        $linkClass = $this->isActive() ? 'class="current" ' : '';
+        $linkTitle = _t(__CLASS__ . '.PUBLISHED_SITE', 'Published Site');
+        $recordLink = Convert::raw2att(Controller::join_links($livePage->AbsoluteLink(), "?stage=Live"));
+        return "<a {$linkClass} href=\"$recordLink\">$linkTitle</a>";
+    }
+
+    public function getTitle()
+    {
+        return _t(
+            __CLASS__ . '.TITLE',
+            'Published',
+            'Used for the Switch between draft and published view mode. Needs to be a short label'
+        );
+    }
+
+    public function getMessage()
+    {
+        return "<div id=\"SilverStripeNavigatorMessage\" title=\"" . _t(
+            SilverStripeNavigatorItem::class . '.WONT_BE_SHOWN',
+            'Note: this message will not be shown to your visitors'
+        ) . "\">" . _t(
+            __CLASS__ . '.PUBLISHED_SITE',
+            'Published Site'
+        ) . "</div>";
+    }
+
+    public function getLink()
+    {
+        $link = $this->getLivePage()->PreviewLink();
+        return $link ? Controller::join_links($link, '?stage=Live') : '';
+    }
+
+    public function canView($member = null)
+    {
+        /** @var Versioned|DataObject $record */
+        $record = $this->record;
+        return (
+            $record->hasExtension(Versioned::class)
+            && $this->showLiveLink()
+            && $record->hasStages()
+            && $this->getLivePage()
+            && $this->getLink()
+        );
+    }
+
+    /**
+     * @return bool
+     */
+    public function showLiveLink()
+    {
+        return (bool)Config::inst()->get(get_class($this->record), 'show_live_link');
+    }
+
+    public function isActive()
+    {
+        return (
+            (!Versioned::get_stage() || Versioned::get_stage() == 'Live')
+            && !$this->isArchived()
+        );
+    }
+
+    protected function getLivePage()
+    {
+        $baseClass = $this->record->baseClass();
+        return Versioned::get_by_stage($baseClass, Versioned::LIVE)->byID($this->record->ID);
+    }
+}

--- a/src/Navigator/SilverStripeNavigatorItem_StageLink.php
+++ b/src/Navigator/SilverStripeNavigatorItem_StageLink.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Navigator;
+
+use SilverStripe\Admin\Navigator\SilverStripeNavigatorItem;
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Convert;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+class SilverStripeNavigatorItem_StageLink extends SilverStripeNavigatorItem
+{
+    private static int $priority = 20;
+
+    public function getHTML()
+    {
+        $draftPage = $this->getDraftPage();
+        if (!$draftPage) {
+            return null;
+        }
+        $linkClass = $this->isActive() ? 'class="current" ' : '';
+        $linkTitle = _t(__CLASS__ . '.DRAFT_SITE', 'Draft Site');
+        $recordLink = Convert::raw2att(Controller::join_links($draftPage->AbsoluteLink(), "?stage=Stage"));
+        return "<a {$linkClass} href=\"$recordLink\">$linkTitle</a>";
+    }
+
+    public function getTitle()
+    {
+        return _t(
+            __CLASS__ . '.TITLE',
+            'Draft',
+            'Used for the Switch between draft and published view mode. Needs to be a short label'
+        );
+    }
+
+    public function getMessage()
+    {
+        return "<div id=\"SilverStripeNavigatorMessage\" title=\"" . _t(
+            SilverStripeNavigatorItem::class . '.WONT_BE_SHOWN',
+            'Note: this message will not be shown to your visitors'
+        ) . "\">" . _t(
+            __CLASS__ . '.DRAFT_SITE',
+            'Draft Site'
+        ) . "</div>";
+    }
+
+    public function getLink()
+    {
+        $date = Versioned::current_archived_date();
+        $link = $this->record->PreviewLink();
+        if (!$link) {
+            return '';
+        }
+        return Controller::join_links(
+            $link,
+            '?stage=Stage',
+            $date ? '?archiveDate=' . $date : null
+        );
+    }
+
+    public function canView($member = null)
+    {
+        /** @var Versioned|DataObject $record */
+        $record = $this->record;
+        return (
+            $record->hasExtension(Versioned::class)
+            && $this->showStageLink()
+            && $record->hasStages()
+            && $this->getDraftPage()
+            && $this->getLink()
+        );
+    }
+
+    /**
+     * @return bool
+     */
+    public function showStageLink()
+    {
+        return (bool)Config::inst()->get(get_class($this->record), 'show_stage_link');
+    }
+
+    public function isActive()
+    {
+        return (
+            Versioned::get_stage() == 'Stage'
+            && !$this->isArchived()
+        );
+    }
+
+    protected function getDraftPage()
+    {
+        $baseClass = $this->record->baseClass();
+        return Versioned::get_by_stage($baseClass, Versioned::DRAFT)->byID($this->record->ID);
+    }
+}

--- a/tests/Navigator/SilverStripeNavigatorTest.php
+++ b/tests/Navigator/SilverStripeNavigatorTest.php
@@ -4,9 +4,9 @@ namespace SilverStripe\VersionedAdmin\Tests\Navigator;
 
 use SilverStripe\Admin\Navigator\SilverStripeNavigator;
 use SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned;
-use SilverStripe\Versioned\Navigator\SilverStripeNavigatorItem_ArchiveLink;
-use SilverStripe\Versioned\Navigator\SilverStripeNavigatorItem_LiveLink;
-use SilverStripe\Versioned\Navigator\SilverStripeNavigatorItem_StageLink;
+use SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink;
+use SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_LiveLink;
+use SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_StageLink;
 use SilverStripe\Dev\SapphireTest;
 
 class SilverStripeNavigatorTest extends SapphireTest

--- a/tests/Navigator/SilverStripeNavigatorTest.php
+++ b/tests/Navigator/SilverStripeNavigatorTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Navigator;
+
+use SilverStripe\Admin\Navigator\SilverStripeNavigator;
+use SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned;
+use SilverStripe\Versioned\Navigator\SilverStripeNavigatorItem_ArchiveLink;
+use SilverStripe\Versioned\Navigator\SilverStripeNavigatorItem_LiveLink;
+use SilverStripe\Versioned\Navigator\SilverStripeNavigatorItem_StageLink;
+use SilverStripe\Dev\SapphireTest;
+
+class SilverStripeNavigatorTest extends SapphireTest
+{
+    protected static $extra_dataobjects = [
+        UnstagedRecord::class,
+        UnversionedRecord::class,
+        VersionedRecord::class,
+    ];
+
+    public function testGetItemsPublished(): void
+    {
+        $record = new VersionedRecord();
+        $record->PreviewLinkTestProperty = 'some-value';
+        $record->write();
+        $record->publishRecursive();
+        $navigator = new SilverStripeNavigator($record);
+        $classes = array_map('get_class', $navigator->getItems()->toArray());
+
+        // Has the live and staged links
+        $this->assertContains(SilverStripeNavigatorItem_LiveLink::class, $classes);
+        $this->assertContains(SilverStripeNavigatorItem_StageLink::class, $classes);
+
+        // Does not have the other links
+        $this->assertNotContains(SilverStripeNavigatorItem_ArchiveLink::class, $classes);
+        $this->assertNotContains(SilverStripeNavigatorItem_Unversioned::class, $classes);
+    }
+
+    public function testGetItemsStaged(): void
+    {
+        $record = new VersionedRecord();
+        $record->PreviewLinkTestProperty = 'some-value';
+        $record->write();
+        $navigator = new SilverStripeNavigator($record);
+        $classes = array_map('get_class', $navigator->getItems()->toArray());
+
+        // Has the stage link
+        $this->assertContains(SilverStripeNavigatorItem_StageLink::class, $classes);
+
+        // Does not have the other links
+        $this->assertNotContains(SilverStripeNavigatorItem_ArchiveLink::class, $classes);
+        $this->assertNotContains(SilverStripeNavigatorItem_LiveLink::class, $classes);
+        $this->assertNotContains(SilverStripeNavigatorItem_Unversioned::class, $classes);
+    }
+
+    public function testGetItemsArchived(): void
+    {
+        $record = new VersionedRecord();
+        $record->PreviewLinkTestProperty = 'some-value';
+        $record->write();
+        $record->doArchive();
+        $navigator = new SilverStripeNavigator($record);
+        $classes = array_map('get_class', $navigator->getItems()->toArray());
+
+        // Has the archived link
+        $this->assertContains(SilverStripeNavigatorItem_ArchiveLink::class, $classes);
+
+        // Does not have the other links
+        $this->assertNotContains(SilverStripeNavigatorItem_LiveLink::class, $classes);
+        $this->assertNotContains(SilverStripeNavigatorItem_StageLink::class, $classes);
+        $this->assertNotContains(SilverStripeNavigatorItem_UnversionedLink::class, $classes);
+    }
+
+    public function testGetItemsUnstaged(): void
+    {
+        $record = new UnstagedRecord();
+        $record->previewLinkTestProperty = 'some-value';
+        $record->write();
+        $navigator = new SilverStripeNavigator($record);
+        $classes = array_map('get_class', $navigator->getItems()->toArray());
+
+        // Has the unversioned link
+        $this->assertContains(SilverStripeNavigatorItem_Unversioned::class, $classes);
+
+        // Does not have the other links
+        $this->assertNotContains(SilverStripeNavigatorItem_ArchiveLink::class, $classes);
+        $this->assertNotContains(SilverStripeNavigatorItem_LiveLink::class, $classes);
+        $this->assertNotContains(SilverStripeNavigatorItem_StageLink::class, $classes);
+    }
+
+    public function testGetItemsUnversioned(): void
+    {
+        $record = new UnversionedRecord();
+        $record->previewLinkTestProperty = 'some-value';
+        $record->write();
+        $navigator = new SilverStripeNavigator($record);
+        $classes = array_map('get_class', $navigator->getItems()->toArray());
+
+        // Has the unversioned link
+        $this->assertContains(SilverStripeNavigatorItem_Unversioned::class, $classes);
+
+        // Does not have the other links
+        $this->assertNotContains(SilverStripeNavigatorItem_ArchiveLink::class, $classes);
+        $this->assertNotContains(SilverStripeNavigatorItem_LiveLink::class, $classes);
+        $this->assertNotContains(SilverStripeNavigatorItem_StageLink::class, $classes);
+    }
+
+    public function testCanViewPublished(): void
+    {
+        $record = new VersionedRecord();
+        $record->write();
+        $record->publishRecursive();
+        $liveLinkItem = new SilverStripeNavigatorItem_LiveLink($record);
+        $stagedLinkItem = new SilverStripeNavigatorItem_StageLink($record);
+        $archivedLinkItem = new SilverStripeNavigatorItem_ArchiveLink($record);
+        $unversionedLinkItem = new SilverStripeNavigatorItem_Unversioned($record);
+
+        // Cannot view staged and live links when there's no preview link
+        $this->assertFalse($liveLinkItem->canView());
+        $this->assertFalse($stagedLinkItem->canView());
+
+        $record->PreviewLinkTestProperty = 'some-value';
+        $record->write();
+        $record->publishRecursive();
+
+        // Can view staged and live links
+        $this->assertTrue($liveLinkItem->canView());
+        $this->assertTrue($stagedLinkItem->canView());
+        // Cannot view the other links
+        $this->assertFalse($archivedLinkItem->canView());
+        $this->assertFalse($unversionedLinkItem->canView());
+    }
+
+    public function testCanViewStaged(): void
+    {
+        $record = new VersionedRecord();
+        $record->write();
+        $liveLinkItem = new SilverStripeNavigatorItem_LiveLink($record);
+        $stagedLinkItem = new SilverStripeNavigatorItem_StageLink($record);
+        $archivedLinkItem = new SilverStripeNavigatorItem_ArchiveLink($record);
+        $unversionedLinkItem = new SilverStripeNavigatorItem_Unversioned($record);
+
+        // Cannot view staged link when there's no preview link
+        $this->assertFalse($stagedLinkItem->canView());
+
+        $record->PreviewLinkTestProperty = 'some-value';
+
+        // Can view staged link
+        $this->assertTrue($stagedLinkItem->canView());
+        // Cannot view the other links
+        $this->assertFalse($liveLinkItem->canView());
+        $this->assertFalse($archivedLinkItem->canView());
+        $this->assertFalse($unversionedLinkItem->canView());
+    }
+
+    public function testCanViewArchived(): void
+    {
+        $record = new VersionedRecord();
+        $record->write();
+        $record->doArchive();
+        $liveLinkItem = new SilverStripeNavigatorItem_LiveLink($record);
+        $stagedLinkItem = new SilverStripeNavigatorItem_StageLink($record);
+        $archivedLinkItem = new SilverStripeNavigatorItem_ArchiveLink($record);
+        $unversionedLinkItem = new SilverStripeNavigatorItem_Unversioned($record);
+
+        // Cannot view archived link when there's no preview link
+        $this->assertFalse($archivedLinkItem->canView());
+
+        $record->PreviewLinkTestProperty = 'some-value';
+
+        // Can view archived link
+        $this->assertTrue($archivedLinkItem->canView());
+        // Cannot view the other links
+        $this->assertFalse($liveLinkItem->canView());
+        $this->assertFalse($stagedLinkItem->canView());
+        $this->assertFalse($unversionedLinkItem->canView());
+    }
+
+    public function testCanViewUnstaged(): void
+    {
+        $record = new UnstagedRecord();
+        $record->write();
+        $liveLinkItem = new SilverStripeNavigatorItem_LiveLink($record);
+        $stagedLinkItem = new SilverStripeNavigatorItem_StageLink($record);
+        $archivedLinkItem = new SilverStripeNavigatorItem_ArchiveLink($record);
+        $unversionedLinkItem = new SilverStripeNavigatorItem_Unversioned($record);
+
+        // Cannot view unversioned link when there's no preview link
+        $this->assertFalse($unversionedLinkItem->canView());
+
+        $record->previewLinkTestProperty = 'some-value';
+
+        // Can view unversioned link
+        $this->assertTrue($unversionedLinkItem->canView());
+        // Cannot view the other links
+        $this->assertFalse($liveLinkItem->canView());
+        $this->assertFalse($stagedLinkItem->canView());
+        $this->assertFalse($archivedLinkItem->canView());
+    }
+
+    public function testCanViewUnversioned(): void
+    {
+        $record = new UnversionedRecord();
+        $record->write();
+        $liveLinkItem = new SilverStripeNavigatorItem_LiveLink($record);
+        $stagedLinkItem = new SilverStripeNavigatorItem_StageLink($record);
+        $archivedLinkItem = new SilverStripeNavigatorItem_ArchiveLink($record);
+        $unversionedLinkItem = new SilverStripeNavigatorItem_Unversioned($record);
+
+        // Cannot view unversioned link when there's no preview link
+        $this->assertFalse($unversionedLinkItem->canView());
+
+        $record->previewLinkTestProperty = 'some-value';
+
+        // Can view unversioned link
+        $this->assertTrue($unversionedLinkItem->canView());
+        // Cannot view the other links
+        $this->assertFalse($liveLinkItem->canView());
+        $this->assertFalse($stagedLinkItem->canView());
+        $this->assertFalse($archivedLinkItem->canView());
+    }
+}

--- a/tests/Navigator/UnstagedRecord.php
+++ b/tests/Navigator/UnstagedRecord.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Navigator;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\CMSPreviewable;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Versioned but not staged
+ */
+class UnstagedRecord extends DataObject implements TestOnly, CMSPreviewable
+{
+    private static $table_name = 'SilverStripeNavigatorTest_UnstagedRecord';
+
+    private static $show_stage_link = true;
+
+    private static $show_live_link = true;
+
+    private static $show_unversioned_preview_link = true;
+
+    private static $extensions = [
+        Versioned::class . '.versioned',
+    ];
+
+    public $previewLinkTestProperty = null;
+
+    public function PreviewLink($action = null)
+    {
+        return $this->previewLinkTestProperty;
+    }
+
+    /**
+     * To determine preview mechanism (e.g. embedded / iframe)
+     *
+     * @return string
+     */
+    public function getMimeType()
+    {
+        return 'text/html';
+    }
+
+    public function CMSEditLink()
+    {
+        return null;
+    }
+}

--- a/tests/Navigator/UnversionedRecord.php
+++ b/tests/Navigator/UnversionedRecord.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Navigator;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\CMSPreviewable;
+use SilverStripe\ORM\DataObject;
+
+class UnversionedRecord extends DataObject implements TestOnly, CMSPreviewable
+{
+    private static $table_name = 'SilverStripeNavigatorTest_UnversionedRecord';
+
+    private static $show_stage_link = true;
+
+    private static $show_live_link = true;
+
+    private static $show_unversioned_preview_link = true;
+
+    public $previewLinkTestProperty = null;
+
+    public function PreviewLink($action = null)
+    {
+        return $this->previewLinkTestProperty;
+    }
+
+    public function getMimeType()
+    {
+        return 'text/html';
+    }
+
+    public function CMSEditLink()
+    {
+        return null;
+    }
+}

--- a/tests/Navigator/VersionedRecord.php
+++ b/tests/Navigator/VersionedRecord.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Navigator;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\CMSPreviewable;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+class VersionedRecord extends DataObject implements TestOnly, CMSPreviewable
+{
+    private static $table_name = 'SilverStripeNavigatorTest_VersionedRecord';
+
+    private static $show_stage_link = true;
+
+    private static $show_live_link = true;
+
+    private static $show_unversioned_preview_link = true;
+
+    private static $db = [
+        'PreviewLinkTestProperty' => 'Text',
+    ];
+
+    private static $extensions = [
+        Versioned::class,
+    ];
+
+    public function PreviewLink($action = null)
+    {
+        return $this->PreviewLinkTestProperty;
+    }
+
+    public function getMimeType()
+    {
+        return 'text/html';
+    }
+
+    public function CMSEditLink()
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
These `SilverStripeNavigatorItem` subclasses are useful for `Versioned` objects without requiring `silverstripe/cms`
I'm not adding them directly to `silverstripe/versioned` because that module has no dependency on `silverstripe/admin` - nor should it.

See also https://github.com/silverstripe/silverstripe-cms/pull/2761

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1339