### PR TITLE
FIX ESLint, SASS-Lint warnings

### DIFF
--- a/client/src/components/HistoryViewer/HistoryViewerVersionList.scss
+++ b/client/src/components/HistoryViewer/HistoryViewerVersionList.scss
@@ -100,7 +100,7 @@
 
 // In detail views, pulls the content (and content tabs) closer to the selected version table
 .history-viewer__table--current {
-  margin-bottom: $panel-padding-y / 2;
+  margin-bottom: calc($panel-padding-y / 2);
 }
 
 .history-viewer {

--- a/client/src/legacy/VersionedEditForm/VersionedEditForm.js
+++ b/client/src/legacy/VersionedEditForm/VersionedEditForm.js
@@ -20,7 +20,7 @@ jQuery.entwine('ss', ($) => {
         'Are you sure you want to remove your record from the published site?\n\nThis record will still be available in the CMS as draft.'
       );
 
-      if (confirm(message)) {
+      if (confirm(message)) { // eslint-disable-line no-alert
         // Add a loading indicator and continue
         this.parents('form:first').addClass('loading');
 
@@ -49,7 +49,7 @@ jQuery.entwine('ss', ($) => {
         'Warning: This record will be unpublished before being sent to the archive.\n\nAre you sure you want to proceed?'
       );
 
-      if (confirm(message)) {
+      if (confirm(message)) { // eslint-disable-line no-alert
         // Add a loading indicator and continue
         this.parents('form:first').addClass('loading');
 


### PR DESCRIPTION
### Description
- Suppressed  `eslint` warnings
- Using `/` for division outside of `calc()` is deprecated and will be removed in Dart Sass 2.0.0.
   -  Replaced divider `/` to `calc(*/*)` function

### Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1416