### PR TITLE
ENH Allow File.keep_archived_assets to show files archive tab

### DIFF
--- a/src/Extensions/FileArchiveExtension.php
+++ b/src/Extensions/FileArchiveExtension.php
@@ -77,6 +77,9 @@ class FileArchiveExtension extends DataExtension implements ArchiveViewProvider
     */
     public function isArchiveFieldEnabled()
     {
-        return Config::inst()->get(AssetControlExtension::class, 'keep_archived_assets');
+        // This should really only check File.keep_archived_assets, though it was originally
+        // only checking AssetControlExtension.keep_archived_assets, so keeping that for BC
+        return Config::inst()->get(AssetControlExtension::class, 'keep_archived_assets')
+          || Config::inst()->get(File::class, 'keep_archived_assets');
     }
 }

--- a/tests/Extensions/FileArchiveExtensionTest.php
+++ b/tests/Extensions/FileArchiveExtensionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Extensions;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Assets\AssetControlExtension;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Assets\File;
+
+class FileArchiveExtensionTest extends SapphireTest
+{
+    /**
+     * @dataProvider provideIsArchiveFieldEnabled
+     */
+    public function testIsArchiveFieldEnabled(
+        bool $assetControlExtension,
+        bool $file,
+        bool $expected
+    ): void {
+        Config::modify()->set(AssetControlExtension::class, 'keep_archived_assets', $assetControlExtension);
+        Config::modify()->set(File::class, 'keep_archived_assets', $file);
+        $actual = File::singleton()->isArchiveFieldEnabled();
+        $this->assertSame($expected, $actual);
+    }
+
+    public function provideIsArchiveFieldEnabled(): array
+    {
+        return [
+            [
+                'assetControlExtension' => false,
+                'file' => false,
+                'expected' => false,
+            ],
+            [
+                'assetControlExtension' => true,
+                'file' => false,
+                'expected' => true,
+            ],
+            [
+                'assetControlExtension' => false,
+                'file' => true,
+                'expected' => true,
+            ],
+            [
+                'assetControlExtension' => true,
+                'file' => true,
+                'expected' => true,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-versioned-admin/issues/300

This should have been checked `File.keep_archived_assets` all along, instead of AssetControlExtension

AssetControlExtension is an extension added to DataObject which is how the `keep_archived_assets` config is on File, so I can see why people though the config should have been read from there, though I think it was an error. We should that config working though for BC

Documentation has it on File - https://docs.silverstripe.org/en/4/developer_guides/files/file_management/#configuring-file-archiving

All the unit-tests that reference 'keep_archived_assets' use `File::config()->set('keep_archived_assets')`
- silverstripe/assets RedirectKeepArchiveFileControllerTest
- silverstripe/assets NormaliseAccessMigrationHelperWithKeepArchivedTest
- silverstripe/assets SS4KeepArchivedFileMigrationHelperTest
