### PR TITLE
FIX Update ArchiveRestoreAction::doRestore() method to pass correct argument in redirection function

### DIFF
--- a/src/Extensions/ArchiveRestoreAction.php
+++ b/src/Extensions/ArchiveRestoreAction.php
@@ -89,6 +89,6 @@ class ArchiveRestoreAction extends DataExtension
         $controller->getRequest()->addHeader('X-Pjax', 'Content');
         $controller->getEditForm()->sessionMessage($message['text'], $message['type'], ValidationResult::CAST_HTML);
 
-        return $controller->redirect($controller->Link(), 'index');
+        return $controller->redirect($controller->Link());
     }
 }


### PR DESCRIPTION
## Description

The redirect function inside `doRestore()` is not compatible to PHP 8.2 with strict argument types. Fixes parameter passed into redirect function.

This only affects CMS 5 due to PHP 8.2 strict type checks and not CMS 4

## Manual testing steps

1. Install Elemental blocks in your CMS
2. Create page
3. Add an elemental block to the page and publish it
4. Publish the page
5. Go back to the elemental block and archive it
6. Go to the Archive section of the CMS
7. Activate the Blocks tab
8. Open the record of the elemental block previously from the Gridfield
9. Click Restore to draft button
10. Expected outcome, will be a success message but an error messages shows instead
11. Refer to the issue submitted below

## Issues

- #330 

## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
