### PR TITLE
API Update method signature to match parent class

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,8 +1,0 @@
-<?php
-
-use SilverStripe\Admin\CMSMenu;
-use SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController;
-use SilverStripe\VersionedAdmin\Controllers\HistoryViewerController;
-
-CMSMenu::remove_menu_class(CMSPageHistoryViewerController::class);
-CMSMenu::remove_menu_class(HistoryViewerController::class);

--- a/src/Controllers/CMSPageHistoryViewerController.php
+++ b/src/Controllers/CMSPageHistoryViewerController.php
@@ -27,6 +27,8 @@ class CMSPageHistoryViewerController extends CMSMain
 
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 
+    private static $ignore_menuitem = true;
+
     public function getEditForm($id = null, $fields = null)
     {
         $record = $this->getRecord($id ?: $this->currentPageID());

--- a/src/Controllers/HistoryViewerController.php
+++ b/src/Controllers/HistoryViewerController.php
@@ -67,7 +67,7 @@ class HistoryViewerController extends LeftAndMain
     /**
      * Returns configuration required by the client app
      */
-    public function getClientConfig()
+    public function getClientConfig(): array
     {
         $clientConfig = parent::getClientConfig();
         foreach ($this->formNames as $formName) {

--- a/src/Controllers/HistoryViewerController.php
+++ b/src/Controllers/HistoryViewerController.php
@@ -42,6 +42,8 @@ class HistoryViewerController extends LeftAndMain
 
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 
+    private static $ignore_menuitem = true;
+
     private static array $url_handlers = [
         'GET api/read' => 'apiRead',
         'POST api/revert' => 'apiRevert',


### PR DESCRIPTION
Two commits:

## Commit 1:
Quick tidyup to use the `ignore_menuitem` configuration property instead of removing the menu item at runtime.

Can't refactor to use `AdminController` instead of `LeftAndMain` yet because it needs formschema - but this small refactor will make that slightly easier when I come to it.

## Commit 2:

Reflects changes in https://github.com/silverstripe/silverstripe-admin/pull/1836

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1761