### PR TITLE
ENH Use versions cache for ArchiveAdmin

### DIFF
--- a/_config/archive-admin.yml
+++ b/_config/archive-admin.yml
@@ -4,6 +4,9 @@ Name: archiveadmin
 SilverStripe\Versioned\VersionedGridFieldItemRequest:
   extensions:
     - SilverStripe\VersionedAdmin\Extensions\ArchiveRestoreAction
+SilverStripe\Forms\GridField\GridField:
+  extensions:
+    - SilverStripe\VersionedAdmin\Extensions\GridFieldExtension
 ---
 Name: pagesarchive
 Only:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/admin": "^3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/versioned": "^3.1"
     },
     "require-dev": {

--- a/src/Extensions/GridFieldExtension.php
+++ b/src/Extensions/GridFieldExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Extensions;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\ORM\DataList;
+use SilverStripe\VersionedAdmin\ArchiveAdmin;
+
+class GridFieldExtension extends Extension
+{
+    protected function onBeforeRenderHolder(GridField $gridField, array $properties): void
+    {
+        $controller = $gridField->getForm()?->getController();
+        if (!$controller || !is_a($controller, ArchiveAdmin::class)) {
+            return;
+        }
+        $list = $gridField->getManipulatedList();
+        if (!is_a($list, DataList::class)) {
+            return;
+        }
+        $list->prepopulateCaches();
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11703

Requires both https://github.com/silverstripe/silverstripe-versioned/pull/501 and https://github.com/silverstripe/silverstripe-framework/pull/11707

To see its effect, archive a couple of pages and then view them in ArchiveAdmin with https://github.com/emteknetnz/silverstripe-db-query-counter/ installed

`Count: 4 - Query: SELECT DISTINCT "SiteTree_Versions"."ClassName", "SiteTree_Versions"."LastEdited", "SiteTree_Versions"."Created", "SiteTree_Versions"."CanViewType", "SiteTree_Versions"."CanEditType", "SiteTree_Versions"."Version", "SiteTree_Versions"."Title", "SiteTree_Versions"."URLSegment", "SiteTree_Versions"."MenuTitle", "SiteTree_Versions"."Content", "SiteTree_Versions"."MetaDescription", "SiteTree_Versions"."ExtraMeta", "SiteTree_Versions"."ShowInMenus", "SiteTree_Versions"."ShowInSearch", "SiteTree_Versions"."Sort", "SiteTree_Versions"."HasBrokenFile", "SiteTree_Versions"."HasBrokenLink", "SiteTree_Versions"."ReportClass", "SiteTree_Versions"."ParentID", "SiteTree_Versions"."ID", CASE WHEN "SiteTree_Versions"."ClassName" IS NOT NULL THEN "SiteTree_Versions"."ClassName" ELSE 'SilverStripe\\CMS\\Model\\SiteTree' END AS "RecordClassName", "SiteTree_Versions"."RecordID", "SiteTree_Versions"."WasPublished", "SiteTree_Versions"."WasDeleted", "SiteTree_Versions"."WasDraft", "SiteTree_Versions"."AuthorID", "SiteTree_Versions"."PublisherID" FROM "SiteTree_Versions" WHERE ("SiteTree_Versions"."RecordID" = ?) ORDER BY "SiteTree_Versions"."LastEdited" DESC, "SiteTree_Versions"."Version" DESC`

Will be reduced down to

`Count: 1 - Query: SELECT DISTINCT "SiteTree_Versions"."ClassName", "SiteTree_Versions"."LastEdited", "SiteTree_Versions"."Created", "SiteTree_Versions"."CanViewType", "SiteTree_Versions"."CanEditType", "SiteTree_Versions"."Version", "SiteTree_Versions"."Title", "SiteTree_Versions"."URLSegment", "SiteTree_Versions"."MenuTitle", "SiteTree_Versions"."Content", "SiteTree_Versions"."MetaDescription", "SiteTree_Versions"."ExtraMeta", "SiteTree_Versions"."ShowInMenus", "SiteTree_Versions"."ShowInSearch", "SiteTree_Versions"."Sort", "SiteTree_Versions"."HasBrokenFile", "SiteTree_Versions"."HasBrokenLink", "SiteTree_Versions"."ReportClass", "SiteTree_Versions"."ParentID", "SiteTree_Versions"."ID", CASE WHEN "SiteTree_Versions"."ClassName" IS NOT NULL THEN "SiteTree_Versions"."ClassName" ELSE 'SilverStripe\\CMS\\Model\\SiteTree' END AS "RecordClassName", "SiteTree_Versions"."RecordID", "SiteTree_Versions"."WasPublished", "SiteTree_Versions"."WasDeleted", "SiteTree_Versions"."WasDraft", "SiteTree_Versions"."AuthorID", "SiteTree_Versions"."PublisherID" FROM "SiteTree_Versions" WHERE ("SiteTree_Versions"."RecordID" IN (?, ?)) ORDER BY "SiteTree_Versions"."LastEdited" DESC, "SiteTree_Versions"."Version" DESC`

Also

`Count: 2 - Query: SELECT "Version" FROM "SiteTree_Live" WHERE "ID" = ?`
and
`Count: 2 - Query: SELECT "Version" FROM "SiteTree" WHERE "ID" = ?`

Will reduce down to

Count: 1 - Query: SELECT "ID", "Version" FROM "SiteTree" WHERE "ID" IN (?, ?)
and
Count: 1 - Query: SELECT "ID", "Version" FROM "SiteTree_Live" WHERE "ID" IN (?, ?)