### PR TITLE
FIX Allow viewing archive history of archived records

### DIFF
--- a/src/Controllers/HistoryViewerController.php
+++ b/src/Controllers/HistoryViewerController.php
@@ -437,7 +437,7 @@ class HistoryViewerController extends FormSchemaController
         if (!$dataClass || !class_exists($dataClass) || !is_a($dataClass, DataObject::class, true)) {
             $this->jsonError(400);
         }
-        $obj = $dataClass::get()->byID($id);
+        $obj = Versioned::get_all_versions($dataClass, $id)->first();
         if (!$obj) {
             $this->jsonError($missingObjectError);
         }


### PR DESCRIPTION
This was failing because `DataObject::get($class)` doesn't return archived records.
I've changed this to now use the same logic the graphql resolvers used (had to discover it by stepping through - there's unfortunately not a super clear way I can point at the code and show it, because it's not clear how GraphQL gets to the code it gets to)

## Issue

- https://github.com/silverstripe/silverstripe-versioned/issues/505