### PR TITLE
FIX Sort records by archive datetime

### DIFF
--- a/src/ArchiveAdmin.php
+++ b/src/ArchiveAdmin.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\VersionedAdmin;
 
+use InvalidArgumentException;
 use SilverStripe\Admin\ModelAdmin;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\ClassInfo;
@@ -24,6 +25,7 @@ use SilverStripe\Versioned\Versioned;
 use SilverStripe\Versioned\VersionedGridFieldState\VersionedGridFieldState;
 use SilverStripe\VersionedAdmin\Interfaces\ArchiveViewProvider;
 use SilverStripe\View\ArrayData;
+use SilverStripe\ORM\DataList;
 
 /**
  * Archive admin is a section of the CMS that displays archived records
@@ -130,6 +132,9 @@ class ArchiveAdmin extends ModelAdmin
      */
     public static function createArchiveGridField($title, $class)
     {
+        if (!is_a($class, DataObject::class, true)) {
+            throw new InvalidArgumentException("Class $class in not a DataObject");
+        }
         $config = GridFieldConfig_Base::create();
         $config->removeComponentsByType(VersionedGridFieldState::class);
         $config->removeComponentsByType(GridFieldFilterHeader::class);
@@ -137,33 +142,7 @@ class ArchiveAdmin extends ModelAdmin
         $config->addComponent(new GridFieldViewButton);
         $config->addComponent(new GridFieldRestoreAction);
         $config->addComponent(new GridField_ActionMenu);
-
-        $singleton = singleton($class);
-        $list = $singleton->get();
-        $baseTable = $singleton->baseTable();
-
-        $list = $list
-            ->setDataQueryParam('Versioned.mode', 'latest_versions');
-        // Join a temporary alias BaseTable_Draft, renaming this on execution to BaseTable
-        // See Versioned::augmentSQL() For reference on this alias
-        $draftTable = $baseTable . '_Draft';
-        $list = $list
-            ->leftJoin(
-                $draftTable,
-                "\"{$baseTable}\".\"ID\" = \"{$draftTable}\".\"ID\""
-            );
-
-        if ($singleton->hasStages()) {
-            $liveTable = $baseTable . '_Live';
-            $list = $list->leftJoin(
-                $liveTable,
-                "\"{$baseTable}\".\"ID\" = \"{$liveTable}\".\"ID\""
-            );
-        }
-
-        $list = $list->where("\"{$draftTable}\".\"ID\" IS NULL");
-        $list = $list->sort('LastEdited DESC');
-
+        $list = ArchiveAdmin::getListForGridField($class);
         $field = GridField::create(
             $title,
             false,
@@ -171,7 +150,6 @@ class ArchiveAdmin extends ModelAdmin
             $config
         );
         $field->setModelClass($class);
-
         return $field;
     }
 
@@ -368,5 +346,44 @@ class ArchiveAdmin extends ModelAdmin
         $forms->first()->LinkOrCurrent = 'link';
 
         return $forms;
+    }
+
+    /**
+     * Gets a Datalist for use on the archive gridfield
+     */
+    private static function getListForGridField(string $dataClass): DataList
+    {
+        /** @var DataObject $dataClass */
+        $obj = DataObject::singleton($dataClass);
+        /** @var DataList $list */
+        $list = $obj->get();
+        $baseTable = $obj->baseTable();
+        // $list = $list->setDataQueryParam('Versioned.mode', 'all_versions');
+        $list = $list->setDataQueryParam([
+            'Versioned.mode' => 'archive',
+            'Versioned.date' => '2100-01-01 00:00:00',
+            'Versioned.stage' => Versioned::DRAFT,
+        ]);
+        p($list->count());
+        // Join a temporary alias BaseTable_Draft, renaming this on execution to BaseTable
+        // See Versioned::augmentSQL() For reference on this alias
+        $draftTable = $baseTable . '_Draft';
+        $list = $list
+            ->leftJoin(
+                $draftTable,
+                "\"{$baseTable}\".\"ID\" = \"{$draftTable}\".\"ID\""
+            );
+        if ($obj->hasStages()) {
+            $liveTable = $baseTable . '_Live';
+            $list = $list->leftJoin(
+                $liveTable,
+                "\"{$baseTable}\".\"ID\" = \"{$liveTable}\".\"ID\""
+            );
+        }
+        $list = $list->where("\"{$draftTable}\".\"ID\" IS NULL");
+        $versionsTable = $baseTable . '_Versions';
+        // $list = $list->where("\"{$versionsTable}\".\"WasDeleted\" = 1");
+        $list = $list->orderBy("\"{$versionsTable}\".\"LastEdited\" DESC");
+        return $list;
     }
 }

--- a/tests/ArchiveAdminTest.php
+++ b/tests/ArchiveAdminTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\VersionedAdmin\Tests;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\VersionedAdmin\ArchiveAdmin;
 use SilverStripe\VersionedAdmin\Tests\ArchiveAdminTest\ChildVersionedObject;
 use SilverStripe\VersionedAdmin\Tests\ArchiveAdminTest\SingleStageObject;
@@ -10,6 +11,8 @@ use SilverStripe\VersionedAdmin\Tests\ArchiveAdminTest\UnversionedObject;
 use SilverStripe\VersionedAdmin\Tests\ArchiveAdminTest\VersionedObject;
 use SilverStripe\VersionedAdmin\Tests\ArchiveAdminTest\ViewProviderChildObject;
 use SilverStripe\VersionedAdmin\Tests\ArchiveAdminTest\ViewProviderVersionedObject;
+use SilverStripe\ORM\DB;
+use ReflectionMethod;
 
 class ArchiveAdminTest extends SapphireTest
 {
@@ -65,11 +68,29 @@ class ArchiveAdminTest extends SapphireTest
         $v->write();
         $v->publishSingle();
 
+        // $obj = DataObject::singleton(VersionedObject::class);
+        // /** @var DataList $list */
+        // $list = $obj->get();
+        // $baseTable = $obj->baseTable();
+        // foreach (DB::query("select * from {$baseTable}_Versions")->getIterator() as $r) {
+        //     p($r);
+        // }
+
         $this->assertEquals([], $grid1->getList()->column('ID'));
 
         $vID = $v->ID;
         $v->doUnpublish();
-        $v->delete();
+        $v->doArchive();
+
+        // foreach (DB::query("select * from {$baseTable}_Versions")->getIterator() as $r) {
+        //     p($r);
+        // }
+
+        $ids = [];
+        p(__FUNCTION__);
+        foreach ($grid1->getList() as $item) {
+            p($item->ID);
+        }
 
         $this->assertEquals([$vID], $grid1->getList()->column('ID'));
 
@@ -84,5 +105,51 @@ class ArchiveAdminTest extends SapphireTest
         $s->delete();
 
         $this->assertEquals([$sID], $grid2->getList()->column('ID'));
+    }
+
+    public function testGetListForGridField(): void
+    {
+        $obj1 = new VersionedObject();
+        $obj2 = new VersionedObject();
+        $obj3 = new VersionedObject();
+        $dataClass = $obj1::class;
+        $baseTable = DataObject::getSchema()->baseDataTable($dataClass);
+        $versionsTable = $baseTable . '_Versions';
+        $id1 = $obj1->write();
+        $id2 = $obj2->write();
+        $id3 = $obj3->write();
+        // Publish and unpublish one of the records to ensure Versioned records are
+        // not being double counted
+        $obj1->publishSingle();
+        $obj1->doUnpublish();
+        $obj1->doArchive();
+        $obj2->doArchive();
+        $obj3->doArchive();
+        // Intentionally updating these 'out of order' i.e. not '01', '02', '03'
+        // to ensure that things are sorted by LastEdited, not just ID
+        $this->updateVersionsTableLastEdited($id1, '02', $versionsTable);
+        $this->updateVersionsTableLastEdited($id2, '01', $versionsTable);
+        $this->updateVersionsTableLastEdited($id3, '03', $versionsTable);
+
+        $admin = new ArchiveAdmin();
+        $refl = new ReflectionMethod($admin, 'getListForGridField');
+        $refl->setAccessible(true);
+        $list = $refl->invoke($admin, $dataClass);
+        $this->assertSame([
+            $id3 => '2025-01-01 00:00:03',
+            $id1 => '2025-01-01 00:00:02',
+            $id2 => '2025-01-01 00:00:01'
+        ], $list->map('RecordID', 'LastEdited')->toArray());
+    }
+
+    private function updateVersionsTableLastEdited(int $recordID, int $seconds, string $versionsTable): void
+    {
+        DB::query(<<<EOT
+            UPDATE "$versionsTable"
+            SET "LastEdited"='2025-01-01 00:00:$seconds'
+            WHERE "RecordID" = $recordID
+            AND "WasDeleted" = 1
+        EOT
+        );
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-versioned-admin/issues/402

This doesn't work, will close PR though leave linked to the issue in case it's helpful for anyone else

The `all_versions` is the version mode that will actually get the everything from the _Versions table which is what we need, however it will return two rows for records that were unpublished and then archived even when filtering on WasDeleted = 1.

Unversioned records will be WasDeleted = 1, WasDraft = 0, WasPublished = 0, so simply filtering on WasDeleted = 1, WasDraft = 1 doesn't work

Also we need to fully use the ORM to get this to work and not just get the list, then get the unique RecordID's, and then do another query based of _Version.ID, as ArchiveAdminTest::testGridFieldList() will fail because that test has an existing DataList in a GridField dynamically update after archive a record in the list

I was surprised that I didn't get 'Versioned.mode' => 'archive' to work, it seems like it's closest to the query we need

We possible will need an entirely new Versioned method to get this to work so that the query is exactly as we need it