### PR TITLE
FIX Remove unnecessary query for versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.3",
         "silverstripe/admin": "^3",
         "silverstripe/framework": "^6",
-        "silverstripe/versioned": "^3"
+        "silverstripe/versioned": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.3",

--- a/src/ArchiveAdmin.php
+++ b/src/ArchiveAdmin.php
@@ -86,11 +86,11 @@ class ArchiveAdmin extends ModelAdmin
                 $listColumns = $listField->getConfig()->getComponentByType(GridFieldDataColumns::class);
                 $listColumns->setDisplayFields([
                     'Title' => _t(__CLASS__ . '.COLUMN_TITLE', 'Title'),
-                    'Versions.first.LastEdited' => _t(__CLASS__ . '.COLUMN_DATEARCHIVED', 'Date Archived'),
-                    'Versions.first.Author.Name' => _t(__CLASS__ . '.COLUMN_ARCHIVEDBY', 'Archived By'),
+                    'LastEdited' => _t(__CLASS__ . '.COLUMN_DATEARCHIVED', 'Date Archived'),
+                    'Author.Name' => _t(__CLASS__ . '.COLUMN_ARCHIVEDBY', 'Archived By'),
                 ]);
                 $listColumns->setFieldFormatting([
-                    'Versions.first.LastEdited' => function ($val, $item) {
+                    'LastEdited' => function ($val, $item) {
                         return DBDatetime::create_field('Datetime', $val)->Ago();
                     },
                 ]);

--- a/src/Extensions/BlockArchiveExtension.php
+++ b/src/Extensions/BlockArchiveExtension.php
@@ -36,12 +36,12 @@ class BlockArchiveExtension extends Extension implements ArchiveViewProvider
         $listColumns->setDisplayFields([
             'Title' => BaseElement::singleton()->fieldLabel('Title'),
             'Type' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_TYPE', 'Type'),
-            'Versions.first.LastEdited' => _t(
+            'LastEdited' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_DATEARCHIVED',
                 'Date Archived'
             ),
             'Breadcrumbs' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ORIGIN', 'Origin'),
-            'Versions.first.Author.Name' => _t(
+            'Author.Name' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ARCHIVEDBY',
                 'Archived By'
             )
@@ -52,7 +52,7 @@ class BlockArchiveExtension extends Extension implements ArchiveViewProvider
 
                 return ($parent && $parent->hasMethod('Breadcrumbs')) ? $parent->Breadcrumbs() : null;
             },
-            'Versions.first.LastEdited' => function ($val, $item) {
+            'LastEdited' => function ($val, $item) {
                 return DBDatetime::create_field('Datetime', $val)->Ago();
             },
         ]);

--- a/src/Extensions/FileArchiveExtension.php
+++ b/src/Extensions/FileArchiveExtension.php
@@ -49,12 +49,12 @@ class FileArchiveExtension extends Extension implements ArchiveViewProvider
         $listColumns->setDisplayFields([
             'Name' => File::singleton()->fieldLabel('Name'),
             'appCategory' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_TYPE', 'Type'),
-            'Versions.first.LastEdited' => _t(
+            'LastEdited' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_DATEARCHIVED',
                 'Date Archived'
             ),
             'Parent.Name' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ORIGIN', 'Origin'),
-            'Versions.first.Author.Name' => _t(
+            'Author.Name' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ARCHIVEDBY',
                 'Archived By'
             )
@@ -63,7 +63,7 @@ class FileArchiveExtension extends Extension implements ArchiveViewProvider
             'appCategory' => function ($val, $item) {
                 return ucfirst($val ?: $item->i18n_singular_name());
             },
-            'Versions.first.LastEdited' => function ($val, $item) {
+            'LastEdited' => function ($val, $item) {
                 return DBDatetime::create_field('Datetime', $val)->Ago();
             },
         ]);

--- a/src/Extensions/SiteTreeArchiveExtension.php
+++ b/src/Extensions/SiteTreeArchiveExtension.php
@@ -36,12 +36,12 @@ class SiteTreeArchiveExtension extends Extension implements ArchiveViewProvider
         $listColumns->setDisplayFields([
             'Title' => SiteTree::singleton()->fieldLabel('Title'),
             'i18n_singular_name' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_TYPE', 'Type'),
-            'Versions.first.LastEdited' => _t(
+            'LastEdited' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_DATEARCHIVED',
                 'Date Archived'
             ),
             'ParentID' => _t('SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ORIGIN', 'Origin'),
-            'Versions.first.Author.Name' => _t(
+            'Author.Name' => _t(
                 'SilverStripe\\VersionedAdmin\\ArchiveAdmin.COLUMN_ARCHIVEDBY',
                 'Archived By'
             )
@@ -57,7 +57,7 @@ class SiteTreeArchiveExtension extends Extension implements ArchiveViewProvider
                     return $breadcrumbString;
                 }
             },
-            'Versions.first.LastEdited' => function ($val, $item) {
+            'LastEdited' => function ($val, $item) {
                 return DBDatetime::create_field('Datetime', $val)->Ago();
             },
         ]);

--- a/tests/Behat/features/archive-order.feature
+++ b/tests/Behat/features/archive-order.feature
@@ -1,0 +1,30 @@
+@javascript @retry @job1
+Feature: Archive order
+  As a CMS author
+  I want to see archived records in order of archived date
+
+  Background:
+    # Note we create in a different order than archiving to ensure the sort order is based explicitly on the archive order
+    Given a "page" "create first, archive second"
+    And a "page" "create second, archive first"
+    And the "page" "create second, archive first" is archived
+    # We have to wait or else they're all archived at the same time and the order will be wrong
+    And I wait for 1 second
+    And the "page" "create first, archive second" is archived
+    And I wait for 1 second
+    And a "page" "create last, archive last"
+    And the "page" "create last, archive last" is archived
+    And the "group" "EDITOR" has permissions "Access to 'Pages' section" and "Access to 'Archive' section"
+    And I am logged in as a member of "EDITOR" group
+
+  Scenario: I can see archived records in the correct order
+    When I go to "/admin/archive"
+    Then I should see "create last, archive last" in the "#Form_EditForm tr:first-of-type .col-Title" element
+    Then I should see "create first, archive second" in the "#Form_EditForm tr:nth-of-type(2) .col-Title" element
+    Then I should see "create second, archive first" in the "#Form_EditForm tr:last-of-type .col-Title" element
+    # reverse the sort order
+    When I press the "action_SetOrderLastEdited" button
+    Then I should see "create second, archive first" in the "#Form_EditForm tr:first-of-type .col-Title" element
+    Then I should see "create first, archive second" in the "#Form_EditForm tr:nth-of-type(2) .col-Title" element
+    Then I should see "create last, archive last" in the "#Form_EditForm tr:last-of-type .col-Title" element
+


### PR DESCRIPTION
A change in silverstripe/versioned fixed a bug where archived records were being ordered by the date the record was last modified _prior to being archived_.
After that fix, we no longer need to explicitly query for versions, since the data we have is already for the archived record.

Relies on changes in https://github.com/silverstripe/silverstripe-versioned/pull/511 and https://github.com/silverstripe/silverstripe-behat-extension/pull/304

## Issue

- https://github.com/silverstripe/silverstripe-versioned-admin/issues/402