### PR TITLE
FIX Don't choke in history view with GridField

### DIFF
--- a/src/Controllers/HistoryViewerController.php
+++ b/src/Controllers/HistoryViewerController.php
@@ -9,6 +9,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\Form;
+use SilverStripe\Forms\FormField;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -136,7 +137,9 @@ class HistoryViewerController extends LeftAndMain
             $specifiesDate = false;
         }
 
-        return $specifiesDate ? $this->getVersionFormByDate($context) : $this->getVersionFormByVersion($context);
+        $form = $specifiesDate ? $this->getVersionFormByDate($context) : $this->getVersionFormByVersion($context);
+        $this->removeUnrenderableFields($form);
+        return $form;
     }
 
     /**
@@ -262,7 +265,7 @@ class HistoryViewerController extends LeftAndMain
         $comparisonTransformation = DiffTransformation::create();
         $form->transform($comparisonTransformation);
         $form->loadDataFrom($recordFrom);
-
+        $this->removeUnrenderableFields($form);
         return $form;
     }
 
@@ -338,5 +341,25 @@ class HistoryViewerController extends LeftAndMain
         return $form->setRequestHandler(
             LeftAndMainFormRequestHandler::create($form, $extra)
         );
+    }
+
+    /**
+     * Remove all form fields that can't be rendered in the history view
+     */
+    private function removeUnrenderableFields(?Form $form): void
+    {
+        if (!$form) {
+            return;
+        }
+        $toRemove = [];
+        $form->Fields()->recursiveWalk(function (FormField $formField) use (&$toRemove) {
+            $schemaData = $formField->getSchemaData();
+            if (!$schemaData['schemaType'] && !$schemaData['component']) {
+                $toRemove[] = $formField->getName();
+            }
+        });
+        if (!empty($toRemove)) {
+            $form->Fields()->removeByName($toRemove);
+        }
     }
 }

--- a/tests/Controllers/HistoryViewerControllerTest.php
+++ b/tests/Controllers/HistoryViewerControllerTest.php
@@ -8,9 +8,12 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\Form;
+use SilverStripe\Forms\NumericField;
+use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\VersionedAdmin\Controllers\HistoryViewerController;
 use SilverStripe\VersionedAdmin\Tests\Controllers\HistoryViewerControllerTest\UnviewableVersionedObject;
 use SilverStripe\VersionedAdmin\Tests\Controllers\HistoryViewerControllerTest\ViewableVersionedObject;
+use SilverStripe\VersionedAdmin\Tests\Controllers\HistoryViewerControllerTest\VersionedObjectWithGridField;
 
 class HistoryViewerControllerTest extends SapphireTest
 {
@@ -19,6 +22,7 @@ class HistoryViewerControllerTest extends SapphireTest
     protected static $extra_dataobjects = [
         ViewableVersionedObject::class,
         UnviewableVersionedObject::class,
+        VersionedObjectWithGridField::class,
     ];
 
     public function testGetClientConfig()
@@ -190,5 +194,40 @@ class HistoryViewerControllerTest extends SapphireTest
         $result = $controllerMock->versionForm(new HTTPRequest('GET', '/', $mockData));
 
         $this->assertSame('mocked', $result);
+    }
+
+    public static function provideFieldsRemovedFromForm(): array
+    {
+        return [
+            [
+                'method' => 'getVersionForm',
+                'expected' => ['Title', 'MyInt', 'SecurityID'],
+            ],
+            [
+                'method' => 'getCompareForm',
+                'expected' => ['Title', 'MyInt'],
+            ],
+        ];
+    }
+
+    /** @dataProvider provideFieldsRemovedFromForm */
+    public function testFieldsRemovedFromForm(string $method, array $expected): void
+    {
+        // Need to update the record so it has a second version of history
+        $record = $this->objFromFixture(VersionedObjectWithGridField::class, 'record_one');
+        $record->MyInt = '1';
+        $record->write();
+        $context = [
+            'RecordClass' => VersionedObjectWithGridField::class,
+            'RecordID' => $record->ID,
+            'RecordVersion' => 1,
+            'RecordVersionFrom' => 1,
+            'RecordVersionTo' => 2,
+        ];
+        $controller = new HistoryViewerController();
+        $this->assertSame(
+            $expected,
+            $controller->$method($context)->Fields()->dataFieldNames(),
+        );
     }
 }

--- a/tests/Controllers/HistoryViewerControllerTest.yml
+++ b/tests/Controllers/HistoryViewerControllerTest.yml
@@ -5,3 +5,7 @@ SilverStripe\VersionedAdmin\Tests\Controllers\HistoryViewerControllerTest\Viewab
 SilverStripe\VersionedAdmin\Tests\Controllers\HistoryViewerControllerTest\UnviewableVersionedObject:
   record_one:
     Title: Record one
+
+SilverStripe\VersionedAdmin\Tests\Controllers\HistoryViewerControllerTest\VersionedObjectWithGridField:
+  record_one:
+    Title: Record one

--- a/tests/Controllers/HistoryViewerControllerTest/NotTransformableGridField.php
+++ b/tests/Controllers/HistoryViewerControllerTest/NotTransformableGridField.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Controllers\HistoryViewerControllerTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\FormTransformation;
+use SilverStripe\Forms\GridField\GridField;
+
+/**
+ * GridField that won't get transformed.
+ * This makes sure that weird setups don't break the compare form.
+ */
+class NotTransformableGridField extends GridField implements TestOnly
+{
+    public function transform(FormTransformation $transformation)
+    {
+        return $this;
+    }
+}

--- a/tests/Controllers/HistoryViewerControllerTest/VersionedObjectWithGridField.php
+++ b/tests/Controllers/HistoryViewerControllerTest/VersionedObjectWithGridField.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Controllers\HistoryViewerControllerTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\GridField\GridFieldConfig_RecordViewer;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+class VersionedObjectWithGridField extends DataObject implements TestOnly
+{
+    private static $db = [
+        'Title' => 'Varchar',
+        'MyInt' => 'Int',
+    ];
+
+    private static $table_name = 'Test_VersionedObjectWithGridField';
+
+    private static $extensions = [
+        Versioned::class,
+    ];
+
+    public function getCMSFields()
+    {
+        $fields = parent::getCMSFields();
+        $fields->addFieldToTab(
+            'Root.Main',
+            NotTransformableGridField::create(
+                'MyGridField',
+                null,
+                static::get(),
+                GridFieldConfig_RecordViewer::create()
+            )
+        );
+        return $fields;
+    }
+}


### PR DESCRIPTION
I know adding config isn't _usually_ done in a patch release, but:
1. There's no risk of adding config causing any new regressions, so it is safe
2. It gives developers a clean way to exclude their custom non-react-able fields from the history view.

Simply excluding GridFields was the behaviour before the exception was added in CMS 5.2, and seems like a sensible behaviour.

## Issue
- https://github.com/silverstripe/silverstripe-versioned-admin/issues/408