### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/admin": "^3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/versioned": "^3.1"
     },
     "require-dev": {

--- a/src/Extensions/SiteTreeArchiveExtension.php
+++ b/src/Extensions/SiteTreeArchiveExtension.php
@@ -48,8 +48,8 @@ class SiteTreeArchiveExtension extends Extension implements ArchiveViewProvider
         ]);
         $listColumns->setFieldFormatting([
             'ParentID' => function ($val, $item) {
-                if (SiteTree::get_by_id($val)) {
-                    $breadcrumbs = SiteTree::get_by_id($val)->getBreadcrumbItems(2);
+                if (SiteTree::get()->setUseCache(true)->byID($val)) {
+                    $breadcrumbs = SiteTree::get()->setUseCache(true)->byID($val)->getBreadcrumbItems(2);
                     $breadcrumbString = '../';
                     foreach ($breadcrumbs as $item) {
                         $breadcrumbString = $breadcrumbString . $item->URLSegment . '/';


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
