### PR TITLE
MNT Better debug info when behat test fails

### DIFF
--- a/tests/Behat/Context/FeatureContext.php
+++ b/tests/Behat/Context/FeatureContext.php
@@ -158,8 +158,9 @@ class FeatureContext extends SilverStripeContext
         $version = $this->getSpecificVersion($versionNumber);
         $authorColumn = $version->find('css', '.history-viewer__author');
 
-        $exists = strpos($authorColumn->getText() ?? '', $text ?? '') !== false;
-        Assert::assertTrue($exists, 'Author column contains ' . $text);
+        $authorText = $authorColumn->getText();
+        $exists = strpos($authorText, $text ?? '') !== false;
+        Assert::assertTrue($exists, 'Author column actually contains: ' . $authorText);
     }
 
     /**
@@ -172,8 +173,9 @@ class FeatureContext extends SilverStripeContext
         $version = $this->getSpecificVersion($versionNumber);
         $recordColumn = $version->find('css', '.history-viewer__version-state');
 
-        $exists = strpos($recordColumn->getText() ?? '', $text ?? '') !== false;
-        Assert::assertTrue($exists, 'Record column contains ' . $text);
+        $recordText = $recordColumn->getText();
+        $exists = strpos($recordText, $text ?? '') !== false;
+        Assert::assertTrue($exists, 'Record column actually contains: ' . $recordText);
     }
 
     /**
@@ -184,8 +186,9 @@ class FeatureContext extends SilverStripeContext
         $version = $this->getSpecificVersion($versionNumber);
         $versionColumn = $version->find('css', '.history-viewer__version-no');
 
-        $exists = strpos($versionColumn->getText() ?? '', $text ?? '') !== false;
-        Assert::assertTrue($exists, 'Version column contains ' . $text);
+        $versionText = $versionColumn->getText();
+        $exists = strpos($versionText, $text ?? '') !== false;
+        Assert::assertTrue($exists, 'Version column actually contains: ' . $versionText);
     }
 
     /**


### PR DESCRIPTION
Rather than re-outputting what you already know you were looking for, this now outputs what is *actually* in that column so you know what went wrong.

Makes debugging failures like https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/17197777224/job/48784803532 easier.

> And I should see "Archived" in the record column in version 1
>      Record column contains Archived
>      Failed asserting that false is true.

## Issue

- https://github.com/tractorcow-farm/silverstripe-fluent/issues/1005