### PR TITLE
MNT Look for archived in the correct version record

### DIFF
--- a/tests/Behat/features/archive-history.feature
+++ b/tests/Behat/features/archive-history.feature
@@ -19,4 +19,4 @@ Feature: View archived history
     # Check the version history
     When I click on "History" in the header tabs
     Then I should see a list of versions
-    And I should see "Archived" in the record column in version 1
+    And I should see "Archived" in the record column in version 4


### PR DESCRIPTION
This PR is consistent with https://github.com/silverstripe/silverstripe-versioned-admin/pull/411 which made the same fix for CMS 6 behat

Behat is failing in new PRs because the version number doesn't match what the behat test expects.

It's not clear why this isn't failing in existing branches - but e.g. see https://github.com/silverstripe/silverstripe-versioned-admin/actions/runs/17199161339/job/48786551902?pr=423 which is failing for https://github.com/silverstripe/silverstripe-versioned-admin/pull/423

> And I should see "Archived" in the record column in version 1
> Record column actually contains: Created 08/25/2025 4:37 AM

The screenshot in the behat artefacts shows the correct version number is 4:

<img width="1024" height="768" alt="archive-history feature_22" src="https://github.com/user-attachments/assets/86bd406d-b107-4a18-b6a7-d1d99fe4f0fd" />


## Issue

- https://github.com/tractorcow-farm/silverstripe-fluent/issues/1005