### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/Controllers/HistoryViewerControllerTest.php
+++ b/tests/Controllers/HistoryViewerControllerTest.php
@@ -311,7 +311,8 @@ class HistoryViewerControllerTest extends FunctionalTest
             $lastEdited = [];
             $versions = Versioned::get_all_versions(get_class($fixture), $fixture->ID);
             foreach ($versions as $version) {
-                $lastEdited[$version->Version] = $version->LastEdited;
+                $key = $version->Version ?? '';
+                $lastEdited[$key] = $version->LastEdited;
             }
             for ($page = 1; $page <= 3; $page++) {
                 $qsa = [];

--- a/tests/Extensions/ArchiveRestoreActionTest.php
+++ b/tests/Extensions/ArchiveRestoreActionTest.php
@@ -83,7 +83,6 @@ class ArchiveRestoreActionTest extends SapphireTest
 
         $ext = new ArchiveRestoreAction();
         $method = new ReflectionMethod(ArchiveRestoreAction::class, 'updateItemEditForm');
-        $method->setAccessible(true);
         $ext->setOwner($itemRequest);
         $method->invokeArgs($ext, [$form]);
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
- Using null as an array offset or when calling array_key_exists() is now deprecated.
