### PR TITLE
MNT Don't use deprecated `FieldList::dataFields()` in test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/admin": "^3",
-        "silverstripe/framework": "^6.1",
+        "silverstripe/framework": "^6.2",
         "silverstripe/versioned": "^3.1"
     },
     "require-dev": {

--- a/tests/Forms/DiffTransformationTest.php
+++ b/tests/Forms/DiffTransformationTest.php
@@ -86,7 +86,7 @@ class DiffTransformationTest extends SapphireTest
         $form->transform($transformation);
         $form->loadDataFrom($oldData);
 
-        foreach (array_values($form->Fields()->dataFields() ?? []) as $index => $field) {
+        foreach (array_values($form->Fields()->getDataFields() ?? []) as $index => $field) {
             $this->assertStringContainsString($expected[$index]['before'], $field->getFormattedValue());
             $this->assertStringContainsString($expected[$index]['after'], $field->getFormattedValue());
         }


### PR DESCRIPTION

## Issue

- https://github.com/silverstripe/silverstripe-elemental/issues/445