### PR TITLE
MNT Remove react as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "moment": "^2.29.4",
     "prop-types": "^15.8.1",
     "qs": "^6.11.0",
-    "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.2.0",
     "react-router": "^6.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10978,13 +10978,6 @@ react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^18.2.0:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
-  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
-  dependencies:
-    loose-envify "^1.1.0"
-
 reactstrap@^9.2.0:
   version "9.2.3"
   resolved "https://registry.yarnpkg.com/reactstrap/-/reactstrap-9.2.3.tgz#45f04617f996177081516a2376a0efc17c4f09f5"


### PR DESCRIPTION
> [!IMPORTANT]
> There's precedent for this - e.g. see asset-admin's `package.json` file which also doesn't have `react` as a dependency.

Running `yarn test` was resulting in errors, because of a mismatch between the instance of react used in versioned-admin components and the instance used in silverstripe/admin components.

Removing the direct dependency resolves the errors by using the react instance from `silverstripe/admin` during tests. This is also consistent with what happens during runtime.

We already need to run `yarn install` inside admin as a sibling directory for `yarn build` to work as expected, so this is a safe change.


Fixes https://github.com/silverstripe/silverstripe-versioned-admin/actions/runs/20981339599

> FAIL client/src/components/HistoryViewer/tests/HistoryViewer-test.js
> 
>     console.error
>       Warning: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
>       1. You might have mismatching versions of React and the renderer (such as React DOM)
>       2. You might be breaking the Rules of Hooks
>       3. You might have more than one copy of React in the same app
>       See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.
> 
> ...
> 
>     console.error
>       Error: Uncaught [TypeError: Cannot read properties of null (reading 'useState')]
> 
> ...
> 
>     TypeError: Cannot read properties of null (reading 'useState')
> 
>       25 | }) => {
>       26 |   // Consolidate size into a single state object to prevent double re-renders
>     > 27 |   const [sizes, setSizes] = useState({ width: undefined, height: undefined });
>          |                                     ^
>       28 |
>       29 |   // Keep the latest onResize prop in a ref.
>       30 |   // This allows the Observer callback to access the latest function
> 
>       at useState (vendor/silverstripe/admin/node_modules/react/cjs/react.development.js:1622:21)
>       at ResizeAware (vendor/silverstripe/admin/client/src/components/ResizeAware/ResizeAware.js:27:37)
> 

## Issue

- https://github.com/silverstripe/.github/issues/474