### PR TITLE
MNT Fix behat test

### DIFF
--- a/tests/Behat/Context/FeatureContext.php
+++ b/tests/Behat/Context/FeatureContext.php
@@ -216,4 +216,19 @@ class FeatureContext extends SilverStripeContext
             }
         }
     }
+
+    /**
+     * @Then I should see :text in the version column at row :row
+     */
+    public function iShouldSeeInTheVersionColumnAtRow($text, $row)
+    {
+        $versions = $this->getVersions();
+        $version = $versions[(int) $row - 1] ?? null;
+        Assert::assertNotNull($version, 'No version found at row ' . $row);
+        $versionColumn = $version->find('css', '.history-viewer__version-no');
+
+        $versionText = $versionColumn->getText();
+        $exists = strpos($versionText, $text ?? '') !== false;
+        Assert::assertTrue($exists, 'Version column actually contains: ' . $versionText);
+    }
 }

--- a/tests/Behat/features/reset-state.feature
+++ b/tests/Behat/features/reset-state.feature
@@ -18,8 +18,7 @@ Feature: Reset state
 
   Scenario: Viewing a version gets reset
     Given I click on "History" in the header tabs
-    # the "first" version aka "version 1" is actually the most recent version - it'll be a version with the number "4"
-    Then I should see 4 in the version column in version 1
+    Then I should see 4 in the version column at row 1
     When I click on the first version
     And I wait for 3 seconds until I see the "#Form_versionForm" element
     Then I should see an "#Form_versionForm_Title[readonly]" element
@@ -28,4 +27,4 @@ Feature: Reset state
     And I wait for 3 seconds
     Then I should see a list of versions in descending order
     And I should not see the "#Form_versionForm" element
-    And I should see 1 in the version column in version 1
+    And I should see 1 in the version column at row 1


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/483

Fixes https://github.com/silverstripe/silverstripe-installer/actions/runs/23419329817/job/68433340792#step:12:429

Look like issue may have been datetime related because FeatureContext::getSpecificVersion() was looking for the string '1' in the entire row text to match the version number, rather than just the column, and that row text contains a date time, but instead it was sometimes matching the data e.g. 06/01/2026, or 10:23AM.

Have updated to just use the row number instead
