### PR TITLE
FIX Preview archived records at their last content version

### DIFF
--- a/src/Extensions/SiteTreeArchiveExtension.php
+++ b/src/Extensions/SiteTreeArchiveExtension.php
@@ -2,14 +2,20 @@
 
 namespace SilverStripe\VersionedAdmin\Extensions;
 
+use SilverStripe\CMS\Forms\SiteTreeURLSegmentField;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Core\Extension;
 use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\Member;
+use SilverStripe\Versioned\Versioned;
 use SilverStripe\VersionedAdmin\ArchiveAdmin;
 use SilverStripe\VersionedAdmin\Interfaces\ArchiveViewProvider;
+use SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink;
 
 /**
  * Adds a archive view for Pages
@@ -77,5 +83,49 @@ class SiteTreeArchiveExtension extends Extension implements ArchiveViewProvider
     public function isArchiveFieldEnabled()
     {
         return true;
+    }
+
+    /**
+     * Point the URL segment field at the archived page.
+     */
+    protected function updateCMSFields(FieldList $fields): void
+    {
+        $owner = $this->getOwner();
+        if (!$owner->isArchived()) {
+            return;
+        }
+
+        $urlSegmentField = $fields->dataFieldByName('URLSegment');
+        if (!$urlSegmentField instanceof SiteTreeURLSegmentField) {
+            return;
+        }
+
+        $archiveDate = SilverStripeNavigatorItem_ArchiveLink::getArchiveDate($owner);
+        if (!$archiveDate) {
+            return;
+        }
+
+        $urlSegmentField
+            ->setURLPrefix(Controller::join_links(Director::absoluteBaseURL(), $this->getParentLink()))
+            ->setURLSuffix('?archiveDate=' . $archiveDate);
+    }
+
+    /**
+     * Relative link of the record's parent, resolved from version history when the parent was
+     * archived as well - the same fallback SiteTree::RelativeLink() applies.
+     */
+    private function getParentLink(): ?string
+    {
+        $owner = $this->getOwner();
+        if (!$owner->ParentID || !SiteTree::config()->get('nested_urls')) {
+            return null;
+        }
+
+        $parent = $owner->getParent();
+        if (!$parent || !$parent->exists()) {
+            $parent = Versioned::get_latest_version(SiteTree::class, $owner->ParentID);
+        }
+
+        return $parent?->RelativeLink(true);
     }
 }

--- a/src/Navigator/SilverStripeNavigatorItem_ArchiveLink.php
+++ b/src/Navigator/SilverStripeNavigatorItem_ArchiveLink.php
@@ -21,7 +21,7 @@ class SilverStripeNavigatorItem_ArchiveLink extends SilverStripeNavigatorItem
         $linkTitle = _t(__CLASS__ . '.PREVIEW', 'Preview version');
         $recordLink = Convert::raw2att(Controller::join_links(
             $this->record->AbsoluteLink(),
-            '?archiveDate=' . urlencode($this->record->LastEdited ?? '')
+            '?archiveDate=' . urlencode(static::getArchiveDate($this->record))
         ));
         return "<a class=\"{$linkClass}\" href=\"$recordLink\" target=\"_blank\">$linkTitle</a>";
     }
@@ -51,7 +51,11 @@ class SilverStripeNavigatorItem_ArchiveLink extends SilverStripeNavigatorItem
     public function getLink()
     {
         $link = $this->record->PreviewLink();
-        return $link ? Controller::join_links($link, '?archiveDate=' . urlencode($this->record->LastEdited ?? '')) : '';
+        if (!$link) {
+            return '';
+        }
+
+        return Controller::join_links($link, '?archiveDate=' . urlencode(static::getArchiveDate($this->record)));
     }
 
     public function canView($member = null)
@@ -71,5 +75,15 @@ class SilverStripeNavigatorItem_ArchiveLink extends SilverStripeNavigatorItem
     public function isActive()
     {
         return $this->isArchived();
+    }
+
+    /**
+     * Date to read the given record at.
+     */
+    public static function getArchiveDate(DataObject $record): string
+    {
+        $latestVersion = Versioned::get_latest_version($record->baseClass(), $record->ID);
+
+        return (string) ($latestVersion?->LastEdited ?: $record->LastEdited ?? '');
     }
 }

--- a/tests/Behat/Context/FeatureContext.php
+++ b/tests/Behat/Context/FeatureContext.php
@@ -2,7 +2,10 @@
 
 namespace SilverStripe\VersionedAdmin\Tests\Behat\Context;
 
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Mink\Element\NodeElement;
+use Exception;
 use PHPUnit\Framework\Assert;
 use SilverStripe\BehatExtension\Context\SilverStripeContext;
 
@@ -12,6 +15,80 @@ if (!class_exists(SilverStripeContext::class)) {
 
 class FeatureContext extends SilverStripeContext
 {
+    /**
+     * Milliseconds to wait for parts of the CMS that are rendered asynchronously. Generous because
+     * CI runners are a lot slower than a development machine.
+     */
+    private const WAIT_TIMEOUT = 10000;
+
+    /**
+     * Unsaved CMS changes trigger a browser "leave site?" dialog on navigation,
+     * including during @AfterScenario cleanup. Chrome leaves the dialog message
+     * empty, causing subsequent WebDriver commands to fail with "unexpected alert open".
+     *
+     * This context runs first in behat.yml to dismiss the dialog before cleanup or
+     * subsequent steps are executed.
+     *
+     * @AfterStep
+     */
+    public function clearUnsavedChangesDialog(AfterStepScope $event)
+    {
+        $driver = $this->getSession()->getDriver();
+        if (!method_exists($driver, 'getWebDriver') || !$driver->isStarted()) {
+            return;
+        }
+
+        try {
+            $driver->getWebDriver()->switchTo()->alert()->accept();
+        } catch (Exception $e) {
+            // No dialog was open, which is the normal case
+        }
+
+        try {
+            $driver->executeScript('window.onbeforeunload = null;');
+        } catch (Exception $e) {
+            // The page may be mid-navigation - the next step re-runs this hook
+        }
+    }
+
+    /**
+     * @BeforeStep
+     */
+    public function waitForHtmlEditors(BeforeStepScope $event)
+    {
+        if (!str_contains($event->getStep()->getText(), 'HTML field')) {
+            return;
+        }
+
+        $driver = $this->getSession()->getDriver();
+        if (!method_exists($driver, 'getWebDriver') || !$driver->isStarted()) {
+            return;
+        }
+
+        // Every htmleditor textarea on the page has to be registered with TinyMCE and finished
+        // initialising. See clearUnsavedChangesDialog() for why the globals are guarded.
+        $ready = $this->getSession()->wait(self::WAIT_TIMEOUT, <<<'JS'
+            (function () {
+                if (!window.tinymce) {
+                    return false;
+                }
+                var textareas = document.querySelectorAll('textarea.htmleditor');
+                if (!textareas.length) {
+                    return false;
+                }
+                for (var i = 0; i < textareas.length; i++) {
+                    var editor = window.tinymce.EditorManager.get(textareas[i].id);
+                    if (!editor || !editor.initialized) {
+                        return false;
+                    }
+                }
+                return true;
+            })()
+            JS);
+
+        Assert::assertTrue($ready, 'The HTML editors on the page did not finish initialising');
+    }
+
     /**
      * @Then I should see a list of versions
      */
@@ -44,8 +121,10 @@ class FeatureContext extends SilverStripeContext
      */
     public function iClickOnTheFirstVersion()
     {
-        Assert::assertNotNull($this->getLatestVersion(), 'I should see a list of versions');
-        $this->getLatestVersion()->click();
+        $version = $this->getLatestVersion();
+        Assert::assertNotFalse($version, 'I should see a list of versions');
+
+        $this->clickVersion($version);
     }
 
     /**
@@ -71,7 +150,16 @@ class FeatureContext extends SilverStripeContext
      */
     public function iOpenTheHistoryViewerActionsMenu()
     {
-        $button = $this->getSession()->getPage()->find('css', '.history-viewer__heading .history-viewer__actions .btn');
+        $selector = '.history-viewer__heading .history-viewer__actions .btn';
+
+        // The heading renders alongside the version list. See clearUnsavedChangesDialog() for why
+        // jQuery is guarded.
+        $this->getSession()->wait(
+            self::WAIT_TIMEOUT,
+            sprintf('window.jQuery && window.jQuery(%s).length > 0', json_encode($selector))
+        );
+
+        $button = $this->getSession()->getPage()->find('css', $selector);
         Assert::assertNotNull($button, 'History viewer actions menu not found in the page.');
 
         $button->click();
@@ -110,8 +198,16 @@ class FeatureContext extends SilverStripeContext
     {
         $version->click();
 
-        // Wait for the form builder to load
-        $this->getSession()->wait(3000, 'window.jQuery("#Form_versionForm").length > 0');
+        // Wait for the form builder to load. In compare mode the form is only rendered once a second
+        // version has been selected, so the compare notice counts as loaded there.
+        // jQuery is guarded because the wait expression is evaluated immediately: while the CMS is
+        // still loading, calling window.jQuery() throws "window.jQuery is not a function" and the
+        // step errors instead of waiting.
+        $this->getSession()->wait(
+            self::WAIT_TIMEOUT,
+            'window.jQuery && (window.jQuery("#Form_versionForm").length > 0'
+                . ' || window.jQuery(".history-viewer__compare-notice").length > 0)'
+        );
     }
 
     /**
@@ -122,13 +218,16 @@ class FeatureContext extends SilverStripeContext
      */
     protected function getVersions($modifier = '')
     {
-        // Wait for the list to be visible
-        $this->getSession()->wait(3000, 'window.jQuery(".history-viewer .table").length > 0');
+        $selector = '.history-viewer__list .history-viewer__table .history-viewer__row' . $modifier;
 
-        $versions = $this->getSession()
-            ->getPage()
-            ->findAll('css', '.history-viewer__list .history-viewer__table .history-viewer__row' . $modifier);
-        return $versions;
+        // Wait for a row rather than the table, which renders before the versions are populated.
+        // See clearUnsavedChangesDialog() for why jQuery is guarded.
+        $this->getSession()->wait(
+            self::WAIT_TIMEOUT,
+            sprintf('window.jQuery && window.jQuery(%s).length > 0', json_encode($selector))
+        );
+
+        return $this->getSession()->getPage()->findAll('css', $selector);
     }
 
     /**
@@ -208,13 +307,21 @@ class FeatureContext extends SilverStripeContext
      */
     protected function getSpecificVersion($versionNumber)
     {
-        $versions = $this->getVersions();
-        foreach ($versions as $version) {
-            /** @var NodeElement $version */
-            if (strpos($version->getText() ?? '', $versionNumber ?? '') !== false) {
-                return $version;
+        // Rows are added to the list as they render, so the version being looked for can arrive
+        // after the first one does. Retry instead of returning null, which left callers to fail
+        // with "Call to a member function find() on null".
+        for ($attempt = 0; $attempt < 10; $attempt++) {
+            foreach ($this->getVersions() as $version) {
+                /** @var NodeElement $version */
+                if (strpos($version->getText() ?? '', $versionNumber ?? '') !== false) {
+                    return $version;
+                }
             }
+
+            usleep(500000);
         }
+
+        Assert::fail(sprintf('No version matching "%s" was found in the version list', $versionNumber));
     }
 
     /**

--- a/tests/Extensions/SiteTreeArchiveExtensionTest.php
+++ b/tests/Extensions/SiteTreeArchiveExtensionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace SilverStripe\VersionedAdmin\Tests\Extensions;
+
+use SilverStripe\CMS\Forms\SiteTreeURLSegmentField;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Versioned\Versioned;
+use SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink;
+
+class SiteTreeArchiveExtensionTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    public function testUrlSegmentFieldLinksToTheArchivedPage(): void
+    {
+        $child = $this->createArchivedPageWithArchivedParent();
+
+        $url = $this->getUrlSegmentField($child)->getURL();
+
+        $this->assertStringContainsString(
+            'parent-page/child-page',
+            $url,
+            'The ancestor path is resolved from version history, even though the parent was archived too'
+        );
+        $this->assertStringNotContainsString(
+            'stage=Stage',
+            $url,
+            'An archived page is not on the draft stage, so a draft link only opens the "page not found" page'
+        );
+        $this->assertStringContainsString('archiveDate=', $url);
+    }
+
+    /**
+     * SiteTreeURLSegmentField.js rebuilds the link as encodeURI(decodeURI(prefix + segment) + suffix),
+     * so anything percent-encoded in the suffix is encoded a second time and the date arrives mangled
+     */
+    public function testUrlSegmentFieldSuffixIsNotPreEncoded(): void
+    {
+        $child = $this->createArchivedPageWithArchivedParent();
+        $field = $this->getUrlSegmentField($child);
+
+        $this->assertStringNotContainsString('%', $field->getURLSuffix());
+
+        // The server-rendered href is still encoded, and decodes back to the version's date
+        parse_str((string) parse_url($field->getURL(), PHP_URL_QUERY), $query);
+        $this->assertSame(
+            SilverStripeNavigatorItem_ArchiveLink::getArchiveDate($child),
+            $query['archiveDate'] ?? null
+        );
+    }
+
+    public function testUrlSegmentFieldMatchesTheArchivePreviewState(): void
+    {
+        $child = $this->createArchivedPageWithArchivedParent();
+
+        $this->assertSame(
+            (new SilverStripeNavigatorItem_ArchiveLink($child))->getLink(),
+            $this->getUrlSegmentField($child)->getURL()
+        );
+    }
+
+    public function testPageOnDraftIsLeftAlone(): void
+    {
+        $page = SiteTree::create(['Title' => 'Draft page', 'URLSegment' => 'draft-page']);
+        $page->write();
+
+        $this->assertStringContainsString('stage=Stage', $this->getUrlSegmentField($page)->getURL());
+    }
+
+    private function createArchivedPageWithArchivedParent(): SiteTree
+    {
+        $parent = SiteTree::create(['Title' => 'Parent page', 'URLSegment' => 'parent-page']);
+        $parent->write();
+        $parent->publishSingle();
+
+        $child = SiteTree::create([
+            'Title' => 'Child page',
+            'URLSegment' => 'child-page',
+            'ParentID' => $parent->ID,
+        ]);
+        $child->write();
+        $child->publishSingle();
+
+        $child->doArchive();
+        $parent->doArchive();
+
+        // The archive admin lists the "deleted" versions of records removed from draft
+        $archived = Versioned::getRemovedFromDraft(SiteTree::class)->byID($child->ID);
+        $this->assertInstanceOf(SiteTree::class, $archived);
+
+        return $archived;
+    }
+
+    /**
+     * The field only knows the page's URL segment once the edit form has loaded the record into it
+     */
+    private function getUrlSegmentField(SiteTree $page): SiteTreeURLSegmentField
+    {
+        $fields = $page->getCMSFields();
+        Form::create(null, 'EditForm', $fields, FieldList::create())->loadDataFrom($page);
+
+        $field = $fields->dataFieldByName('URLSegment');
+        $this->assertInstanceOf(SiteTreeURLSegmentField::class, $field);
+
+        return $field;
+    }
+}

--- a/tests/Navigator/SilverStripeNavigatorTest.php
+++ b/tests/Navigator/SilverStripeNavigatorTest.php
@@ -4,6 +4,8 @@ namespace SilverStripe\VersionedAdmin\Tests\Navigator;
 
 use SilverStripe\Admin\Navigator\SilverStripeNavigator;
 use SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\Versioned\Versioned;
 use SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink;
 use SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_LiveLink;
 use SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_StageLink;
@@ -68,6 +70,41 @@ class SilverStripeNavigatorTest extends SapphireTest
         $this->assertNotContains(SilverStripeNavigatorItem_LiveLink::class, $classes);
         $this->assertNotContains(SilverStripeNavigatorItem_StageLink::class, $classes);
         $this->assertNotContains(SilverStripeNavigatorItem_UnversionedLink::class, $classes);
+    }
+
+    public function testArchiveLinkUsesTheDateOfTheLastContentVersion(): void
+    {
+        $record = DBDatetime::withFixedNow('2026-05-01 09:00:00', function (): VersionedRecord {
+            $record = new VersionedRecord();
+            $record->PreviewLinkTestProperty = 'some-value';
+            $record->write();
+            $record->publishRecursive();
+
+            return $record;
+        });
+        DBDatetime::withFixedNow('2026-05-08 14:30:00', function () use ($record): void {
+            $record->doArchive();
+        });
+
+        // ArchiveAdmin lists the version written by the archive, whose LastEdited is the moment of
+        // archiving - a date the archive reading mode resolves back to that (unqueryable) version
+        $archived = Versioned::getRemovedFromDraft(VersionedRecord::class)->byID($record->ID);
+        $item = new SilverStripeNavigatorItem_ArchiveLink($archived);
+
+        $this->assertStringContainsString('archiveDate=' . urlencode('2026-05-01 09:00:00'), $item->getLink());
+        $this->assertStringNotContainsString(urlencode('2026-05-08 14:30:00'), $item->getLink());
+    }
+
+    public function testArchiveLinkFallsBackToTheRecordDateWithoutAContentVersion(): void
+    {
+        $record = new VersionedRecord();
+        $record->PreviewLinkTestProperty = 'some-value';
+        $record->write();
+        $lastEdited = $record->LastEdited;
+
+        $item = new SilverStripeNavigatorItem_ArchiveLink($record);
+
+        $this->assertStringContainsString('archiveDate=' . urlencode($lastEdited), $item->getLink());
     }
 
     public function testGetItemsUnstaged(): void


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
**Expected:** the archive admin's preview panel shows an archived page as it was when it was archived.

**Observed:** the panel renders the site's "page not found" error page.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
1. Create a page, publish it, then wait for a few seconds so the timestamps are different, and then unpublish and archive it.
2. Go to `/admin/archive` and use the **View** action on the archived page.
3. Before: the preview panel shows the "page not found" page, and the iframe URL carries
   `?archiveDate=<time you archived it>`. After: the panel shows the page content, and the URL
   carries `?archiveDate=<time you last saved it>`.
4. Regression check: non-archived records are untouched: open any published page in **Pages** and
   confirm the Draft/Published preview states still work.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #478 

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
